### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/102/026/261/102026261.geojson
+++ b/data/102/026/261/102026261.geojson
@@ -57,6 +57,9 @@
         "qs_pg:id":137011
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91ca1c668d10abf98789378e86c5e703",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":102026261,
-    "wof:lastmodified":1566586180,
+    "wof:lastmodified":1582331593,
     "wof:name":"Neietsu",
     "wof:parent_id":890476059,
     "wof:placetype":"locality",

--- a/data/102/026/263/102026263.geojson
+++ b/data/102/026/263/102026263.geojson
@@ -225,6 +225,9 @@
         "wd:id":"Q18459"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bcf08394cb63b896fcaed3d3d7820c7c",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":102026263,
-    "wof:lastmodified":1566586195,
+    "wof:lastmodified":1582331595,
     "wof:name":"Yongin",
     "wof:parent_id":1108746545,
     "wof:placetype":"locality",

--- a/data/102/026/265/102026265.geojson
+++ b/data/102/026/265/102026265.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":137014
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ba6d2213322e4f0e6523aab6df34222",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":102026265,
-    "wof:lastmodified":1566586194,
+    "wof:lastmodified":1582331595,
     "wof:name":"Y\u014fng-dong",
     "wof:parent_id":890473559,
     "wof:placetype":"locality",

--- a/data/102/026/269/102026269.geojson
+++ b/data/102/026/269/102026269.geojson
@@ -57,6 +57,9 @@
         "qs_pg:id":372346
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"667ebb165e577512c8b617d905ff0afe",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":102026269,
-    "wof:lastmodified":1566586182,
+    "wof:lastmodified":1582331593,
     "wof:name":"\uc5f0\ucc9c\uad70",
     "wof:parent_id":890475965,
     "wof:placetype":"locality",

--- a/data/102/026/271/102026271.geojson
+++ b/data/102/026/271/102026271.geojson
@@ -203,6 +203,9 @@
         "wk:page":"Yeoju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d40c5b99c4710dcab1aca6a5f37aab9",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":102026271,
-    "wof:lastmodified":1566586191,
+    "wof:lastmodified":1582331595,
     "wof:name":"Yeoju",
     "wof:parent_id":1108746541,
     "wof:placetype":"locality",

--- a/data/102/026/273/102026273.geojson
+++ b/data/102/026/273/102026273.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Yesan County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"33419947d1b0be3425358913b7d6ad88",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":102026273,
-    "wof:lastmodified":1566586177,
+    "wof:lastmodified":1582331593,
     "wof:name":"Yesan",
     "wof:parent_id":890474695,
     "wof:placetype":"locality",

--- a/data/102/026/279/102026279.geojson
+++ b/data/102/026/279/102026279.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Yangpyeong County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c758e8ba8804d6b84bbc5e179ab5360a",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":102026279,
-    "wof:lastmodified":1566586190,
+    "wof:lastmodified":1582331594,
     "wof:name":"Yangp'y\u014fng",
     "wof:parent_id":890475313,
     "wof:placetype":"locality",

--- a/data/102/026/281/102026281.geojson
+++ b/data/102/026/281/102026281.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Yangju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7d5f50a4902b4c259922fecaa542570",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586179,
+    "wof:lastmodified":1582331593,
     "wof:name":"Yangju",
     "wof:parent_id":890475429,
     "wof:placetype":"locality",

--- a/data/102/026/283/102026283.geojson
+++ b/data/102/026/283/102026283.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Yanggu County, Gangwon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a6265134108db6a9231dbe91a1bfe1d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":102026283,
-    "wof:lastmodified":1566586190,
+    "wof:lastmodified":1582331594,
     "wof:name":"Yanggu",
     "wof:parent_id":890474685,
     "wof:placetype":"locality",

--- a/data/102/026/285/102026285.geojson
+++ b/data/102/026/285/102026285.geojson
@@ -317,6 +317,9 @@
         "wk:page":"Wonju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"159a0cacbe8e551d15daa6461052858c",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         }
     ],
     "wof:id":102026285,
-    "wof:lastmodified":1566586191,
+    "wof:lastmodified":1582331595,
     "wof:name":"W\u014fnju",
     "wof:parent_id":890473183,
     "wof:placetype":"locality",

--- a/data/102/026/287/102026287.geojson
+++ b/data/102/026/287/102026287.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Wanju County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a048d84400bfb5b1cf99a3c3664f7807",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":102026287,
-    "wof:lastmodified":1566586177,
+    "wof:lastmodified":1582331593,
     "wof:name":"Wanju",
     "wof:parent_id":890474683,
     "wof:placetype":"locality",

--- a/data/102/026/289/102026289.geojson
+++ b/data/102/026/289/102026289.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q485201"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"337b0d1411822de22911a20e1bbed7e2",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":102026289,
-    "wof:lastmodified":1566586178,
+    "wof:lastmodified":1582331593,
     "wof:name":"Waegwan",
     "wof:parent_id":890475279,
     "wof:placetype":"locality",

--- a/data/102/026/291/102026291.geojson
+++ b/data/102/026/291/102026291.geojson
@@ -369,6 +369,9 @@
         "qs_pg:id":1111153
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03e8500d426df01a601dc92d77439b98",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
         }
     ],
     "wof:id":102026291,
-    "wof:lastmodified":1566586193,
+    "wof:lastmodified":1582331595,
     "wof:megacity":1,
     "wof:name":"Ulsan",
     "wof:parent_id":1108746505,

--- a/data/102/026/299/102026299.geojson
+++ b/data/102/026/299/102026299.geojson
@@ -211,6 +211,9 @@
         "wd:id":"Q42135"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"992a534b088f55848fa80b8941130861",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":102026299,
-    "wof:lastmodified":1566586195,
+    "wof:lastmodified":1582331595,
     "wof:name":"Vijongbu",
     "wof:parent_id":890475299,
     "wof:placetype":"locality",

--- a/data/102/026/309/102026309.geojson
+++ b/data/102/026/309/102026309.geojson
@@ -197,6 +197,9 @@
         "wk:page":"Dangjin"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c78578c414bf282e21eb896c73349186",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
         }
     ],
     "wof:id":102026309,
-    "wof:lastmodified":1566586172,
+    "wof:lastmodified":1582331592,
     "wof:name":"Tangjin",
     "wof:parent_id":1108746439,
     "wof:placetype":"locality",

--- a/data/102/026/311/102026311.geojson
+++ b/data/102/026/311/102026311.geojson
@@ -395,6 +395,9 @@
         "qs_pg:id":351248
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"543b3b389344238d704625ca27f01d06",
     "wof:hierarchy":[
         {
@@ -409,7 +412,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586196,
+    "wof:lastmodified":1582331596,
     "wof:megacity":1,
     "wof:name":"Daejeon",
     "wof:parent_id":1108746515,

--- a/data/102/026/315/102026315.geojson
+++ b/data/102/026/315/102026315.geojson
@@ -454,6 +454,9 @@
         "wd:id":"Q20927"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49cc68085280e1d97eb276782745fbae",
     "wof:hierarchy":[
         {
@@ -465,7 +468,7 @@
         }
     ],
     "wof:id":102026315,
-    "wof:lastmodified":1566586185,
+    "wof:lastmodified":1582331594,
     "wof:megacity":1,
     "wof:name":"Daegu",
     "wof:parent_id":1108746395,

--- a/data/102/026/319/102026319.geojson
+++ b/data/102/026/319/102026319.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Taebaek"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3af5f2984af86836f0c1c6b06ddea26a",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":102026319,
-    "wof:lastmodified":1566586198,
+    "wof:lastmodified":1582331596,
     "wof:name":"T\u2019aebaek",
     "wof:parent_id":890475963,
     "wof:placetype":"locality",

--- a/data/102/026/323/102026323.geojson
+++ b/data/102/026/323/102026323.geojson
@@ -389,6 +389,9 @@
         "qs_pg:id":900323
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f649c474545a9ac1a2a435a82dd79399",
     "wof:hierarchy":[
         {
@@ -403,7 +406,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586184,
+    "wof:lastmodified":1582331594,
     "wof:megacity":1,
     "wof:name":"Suigen",
     "wof:parent_id":85673191,

--- a/data/102/026/325/102026325.geojson
+++ b/data/102/026/325/102026325.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Suncheon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f73a0b166de2c8c078e2a4ecb550eda",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":102026325,
-    "wof:lastmodified":1566586186,
+    "wof:lastmodified":1582331594,
     "wof:name":"Sunchun",
     "wof:parent_id":890474635,
     "wof:placetype":"locality",

--- a/data/102/026/327/102026327.geojson
+++ b/data/102/026/327/102026327.geojson
@@ -801,6 +801,9 @@
         85673185
     ],
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd3798b0411e736bddaa658684ff72ee",
     "wof:hierarchy":[
         {
@@ -815,7 +818,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586196,
+    "wof:lastmodified":1582331595,
     "wof:megacity":1,
     "wof:name":"Seoul",
     "wof:parent_id":890475295,

--- a/data/102/026/329/102026329.geojson
+++ b/data/102/026/329/102026329.geojson
@@ -212,6 +212,9 @@
         "wk:page":"Seosan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b895dca5c14bc00af370d31b32cb6856",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586196,
+    "wof:lastmodified":1582331596,
     "wof:name":"Suisan",
     "wof:parent_id":890475035,
     "wof:placetype":"locality",

--- a/data/102/026/333/102026333.geojson
+++ b/data/102/026/333/102026333.geojson
@@ -71,6 +71,9 @@
         "wk:page":"Seonsan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4dfe6aed27a176bc229a29de84410a74",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":102026333,
-    "wof:lastmodified":1566586189,
+    "wof:lastmodified":1582331594,
     "wof:name":"Jenzan",
     "wof:parent_id":890472251,
     "wof:placetype":"locality",

--- a/data/102/026/335/102026335.geojson
+++ b/data/102/026/335/102026335.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Sokcho"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76e6ae649407bf25fd9bb7c1358a4eb4",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":102026335,
-    "wof:lastmodified":1566586188,
+    "wof:lastmodified":1582331594,
     "wof:name":"Sogcho",
     "wof:parent_id":890476055,
     "wof:placetype":"locality",

--- a/data/102/026/339/102026339.geojson
+++ b/data/102/026/339/102026339.geojson
@@ -206,6 +206,9 @@
         "wk:page":"Sangju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3bfe1ab4d91931c9b987eaa5cdf7f063",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":102026339,
-    "wof:lastmodified":1566586174,
+    "wof:lastmodified":1582331592,
     "wof:name":"Sangju",
     "wof:parent_id":890472345,
     "wof:placetype":"locality",

--- a/data/102/026/341/102026341.geojson
+++ b/data/102/026/341/102026341.geojson
@@ -199,6 +199,9 @@
         "wd:id":"Q42102"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd333c786fa4635fe847a28603afa46b",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":102026341,
-    "wof:lastmodified":1566586183,
+    "wof:lastmodified":1582331593,
     "wof:name":"Santyoku",
     "wof:parent_id":890476189,
     "wof:placetype":"locality",

--- a/data/102/026/351/102026351.geojson
+++ b/data/102/026/351/102026351.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Buyeo County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9610c900fd8d1450af4431c029e758c",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":102026351,
-    "wof:lastmodified":1566586189,
+    "wof:lastmodified":1582331594,
     "wof:name":"Fuyo",
     "wof:parent_id":890473525,
     "wof:placetype":"locality",

--- a/data/102/026/353/102026353.geojson
+++ b/data/102/026/353/102026353.geojson
@@ -521,6 +521,9 @@
         "wk:page":"Busan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"687baca33a1e4db523973b096aac9a1b",
     "wof:hierarchy":[
         {
@@ -532,7 +535,7 @@
         }
     ],
     "wof:id":102026353,
-    "wof:lastmodified":1566586173,
+    "wof:lastmodified":1582331592,
     "wof:megacity":1,
     "wof:name":"Busan",
     "wof:parent_id":890474617,

--- a/data/102/026/355/102026355.geojson
+++ b/data/102/026/355/102026355.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Bucheon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e924176d6a95de31bd50547747ba435",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586175,
+    "wof:lastmodified":1582331592,
     "wof:megacity":1,
     "wof:name":"Bucheon",
     "wof:parent_id":1108746419,

--- a/data/102/026/357/102026357.geojson
+++ b/data/102/026/357/102026357.geojson
@@ -213,6 +213,9 @@
         "wk:page":"Pohang"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"858981386056efb6930192af69d57063",
     "wof:hierarchy":[
         {
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":102026357,
-    "wof:lastmodified":1566586188,
+    "wof:lastmodified":1582331594,
     "wof:name":"Hoko",
     "wof:parent_id":1108746427,
     "wof:placetype":"locality",

--- a/data/102/026/359/102026359.geojson
+++ b/data/102/026/359/102026359.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Osan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f917c4ae40679cf7ecbe5d881a4a94e",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":102026359,
-    "wof:lastmodified":1566586187,
+    "wof:lastmodified":1582331594,
     "wof:name":"Osan",
     "wof:parent_id":890473335,
     "wof:placetype":"locality",

--- a/data/102/026/361/102026361.geojson
+++ b/data/102/026/361/102026361.geojson
@@ -193,6 +193,9 @@
         "wk:page":"Asan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb5bb0e6cdf427f20bb190ef12c1416a",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586186,
+    "wof:lastmodified":1582331594,
     "wof:name":"Asan",
     "wof:parent_id":890475539,
     "wof:placetype":"locality",

--- a/data/102/026/363/102026363.geojson
+++ b/data/102/026/363/102026363.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Okcheon County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dff17f41fb8be5fe0182bab51dad3739",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":102026363,
-    "wof:lastmodified":1566586175,
+    "wof:lastmodified":1582331592,
     "wof:name":"\uc625\ucc9c\uad70",
     "wof:parent_id":890475545,
     "wof:placetype":"locality",

--- a/data/102/026/365/102026365.geojson
+++ b/data/102/026/365/102026365.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Goseong County, Gangwon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b91e83fbbe5e5d97584c444d1c7ed4a",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":102026365,
-    "wof:lastmodified":1566586173,
+    "wof:lastmodified":1582331592,
     "wof:name":"Kosong",
     "wof:parent_id":890475465,
     "wof:placetype":"locality",

--- a/data/102/026/369/102026369.geojson
+++ b/data/102/026/369/102026369.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Nonsan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8c50521eae3e6fdfc9b37d8fa95f8b33",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586188,
+    "wof:lastmodified":1582331594,
     "wof:name":"Nonsan",
     "wof:parent_id":890474443,
     "wof:placetype":"locality",

--- a/data/102/026/371/102026371.geojson
+++ b/data/102/026/371/102026371.geojson
@@ -194,6 +194,9 @@
         "wk:page":"Namwon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92a054d79025f3e31845d806fd6e9b1f",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":102026371,
-    "wof:lastmodified":1566586185,
+    "wof:lastmodified":1582331594,
     "wof:name":"Nangen",
     "wof:parent_id":890475797,
     "wof:placetype":"locality",

--- a/data/102/026/373/102026373.geojson
+++ b/data/102/026/373/102026373.geojson
@@ -80,6 +80,9 @@
         "wd:id":"Q498474"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99d19bdbccd0844d9489a51a4561831a",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":102026373,
-    "wof:lastmodified":1566586197,
+    "wof:lastmodified":1582331596,
     "wof:name":"Munsan",
     "wof:parent_id":890476051,
     "wof:placetype":"locality",

--- a/data/102/026/375/102026375.geojson
+++ b/data/102/026/375/102026375.geojson
@@ -205,6 +205,9 @@
         "wk:page":"Mungyeong"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc939f0abfe915131a31159f0d1ee8d8",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586199,
+    "wof:lastmodified":1582331596,
     "wof:name":"Mungyeong",
     "wof:parent_id":890476201,
     "wof:placetype":"locality",

--- a/data/102/026/383/102026383.geojson
+++ b/data/102/026/383/102026383.geojson
@@ -219,6 +219,9 @@
         "wd:id":"Q42059"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f3bdc64f19be4a370a6e27d217ad55c",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586183,
+    "wof:lastmodified":1582331593,
     "wof:name":"Keizan",
     "wof:parent_id":890476211,
     "wof:placetype":"locality",

--- a/data/102/026/387/102026387.geojson
+++ b/data/102/026/387/102026387.geojson
@@ -336,6 +336,9 @@
         "wk:page":"Gyeongju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b669437cec79b1f3d6de5a0b32233d1c",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586198,
+    "wof:lastmodified":1582331596,
     "wof:name":"Kyonju",
     "wof:parent_id":890472443,
     "wof:placetype":"locality",

--- a/data/102/026/389/102026389.geojson
+++ b/data/102/026/389/102026389.geojson
@@ -229,6 +229,9 @@
         "qs_pg:id":1145936
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"28e81eff454478a5d3b64f0f7043f527",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586197,
+    "wof:lastmodified":1582331596,
     "wof:name":"Kwangju",
     "wof:parent_id":1108746519,
     "wof:placetype":"locality",

--- a/data/102/026/393/102026393.geojson
+++ b/data/102/026/393/102026393.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":208473
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"722d3c2bd7c420b00b025ee39477a609",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":102026393,
-    "wof:lastmodified":1566586189,
+    "wof:lastmodified":1582331594,
     "wof:name":"Kurye",
     "wof:parent_id":890475069,
     "wof:placetype":"locality",

--- a/data/102/026/395/102026395.geojson
+++ b/data/102/026/395/102026395.geojson
@@ -217,6 +217,9 @@
         "wk:page":"Guri"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"33e326361f9a973a8de01b85a41a4a58",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":102026395,
-    "wof:lastmodified":1566586187,
+    "wof:lastmodified":1582331594,
     "wof:name":"Kuri",
     "wof:parent_id":890474591,
     "wof:placetype":"locality",

--- a/data/102/026/397/102026397.geojson
+++ b/data/102/026/397/102026397.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":276641
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21198baa03c026573e78d6d8041c79df",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":102026397,
-    "wof:lastmodified":1566586175,
+    "wof:lastmodified":1582331592,
     "wof:name":"Kunwi",
     "wof:parent_id":890474969,
     "wof:placetype":"locality",

--- a/data/102/026/399/102026399.geojson
+++ b/data/102/026/399/102026399.geojson
@@ -321,6 +321,9 @@
         "qs_pg:id":1200408
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f157caf26c3948b4a78f8d3f3112a927",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586175,
+    "wof:lastmodified":1582331592,
     "wof:name":"Kunsan",
     "wof:parent_id":890475397,
     "wof:placetype":"locality",

--- a/data/102/026/409/102026409.geojson
+++ b/data/102/026/409/102026409.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Gumi, North Gyeongsang"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ac9f5eddc673b2704fb042f58fa271d",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":102026409,
-    "wof:lastmodified":1566586181,
+    "wof:lastmodified":1582331593,
     "wof:name":"Kumi",
     "wof:parent_id":890472251,
     "wof:placetype":"locality",

--- a/data/102/026/411/102026411.geojson
+++ b/data/102/026/411/102026411.geojson
@@ -348,6 +348,9 @@
         "wk:page":"Goyang"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce9f36a6e483ce935caa53b23bfd7e74",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586191,
+    "wof:lastmodified":1582331595,
     "wof:megacity":1,
     "wof:name":"Goyang",
     "wof:parent_id":1108746465,

--- a/data/102/026/413/102026413.geojson
+++ b/data/102/026/413/102026413.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Goseong County, South Gyeongsang"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6cc5fccdd988cbd2d79e4abd215e9638",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":102026413,
-    "wof:lastmodified":1566586177,
+    "wof:lastmodified":1582331593,
     "wof:name":"Goseong",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/102/026/417/102026417.geojson
+++ b/data/102/026/417/102026417.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Gongju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5abceeac748c0a0839b7f5e626fa82d3",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586190,
+    "wof:lastmodified":1582331594,
     "wof:name":"Kongju",
     "wof:parent_id":890472413,
     "wof:placetype":"locality",

--- a/data/102/026/419/102026419.geojson
+++ b/data/102/026/419/102026419.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Goesan County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64ef02a10e6f6f645583394c86712fa6",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":102026419,
-    "wof:lastmodified":1566586190,
+    "wof:lastmodified":1582331594,
     "wof:name":"Koesan",
     "wof:parent_id":890473945,
     "wof:placetype":"locality",

--- a/data/102/026/423/102026423.geojson
+++ b/data/102/026/423/102026423.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Gochang County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67a80f3a9d8be0f179112996660290f5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":102026423,
-    "wof:lastmodified":1566586179,
+    "wof:lastmodified":1582331593,
     "wof:name":"Koch'ang",
     "wof:parent_id":890475485,
     "wof:placetype":"locality",

--- a/data/102/026/427/102026427.geojson
+++ b/data/102/026/427/102026427.geojson
@@ -200,6 +200,9 @@
         "wk:page":"Gimje"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb246b89a211698ddce81ad5ea84cda2",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":102026427,
-    "wof:lastmodified":1566586192,
+    "wof:lastmodified":1582331595,
     "wof:name":"Kimje",
     "wof:parent_id":890473531,
     "wof:placetype":"locality",

--- a/data/102/026/429/102026429.geojson
+++ b/data/102/026/429/102026429.geojson
@@ -211,6 +211,9 @@
         "wd:id":"Q42082"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e045b78dc22c48feb8c05f57f1f6f89",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":102026429,
-    "wof:lastmodified":1566586191,
+    "wof:lastmodified":1582331595,
     "wof:name":"Kimhae",
     "wof:parent_id":890475303,
     "wof:placetype":"locality",

--- a/data/102/026/431/102026431.geojson
+++ b/data/102/026/431/102026431.geojson
@@ -165,6 +165,9 @@
         "wk:page":"Gimcheon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb5c171f92a6e34520a57303cb865eed",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":102026431,
-    "wof:lastmodified":1566586181,
+    "wof:lastmodified":1582331593,
     "wof:name":"Gimcheon",
     "wof:parent_id":890473179,
     "wof:placetype":"locality",

--- a/data/102/026/433/102026433.geojson
+++ b/data/102/026/433/102026433.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1027785
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2266ff0b2bf92e111999ff3bb2420575",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":102026433,
-    "wof:lastmodified":1566586194,
+    "wof:lastmodified":1582331595,
     "wof:name":"Gapyeong",
     "wof:parent_id":890472417,
     "wof:placetype":"locality",

--- a/data/102/026/435/102026435.geojson
+++ b/data/102/026/435/102026435.geojson
@@ -340,6 +340,9 @@
         "wk:page":"Gangneung"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"136f10e5d34e40111db6051e8e5fac87",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586195,
+    "wof:lastmodified":1582331595,
     "wof:name":"Kang-neung",
     "wof:parent_id":890476169,
     "wof:placetype":"locality",

--- a/data/102/026/437/102026437.geojson
+++ b/data/102/026/437/102026437.geojson
@@ -170,6 +170,9 @@
         "wd:id":"Q494786"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7b7def1d4e01991d7550af789df330f5",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":102026437,
-    "wof:lastmodified":1566586180,
+    "wof:lastmodified":1582331593,
     "wof:name":"Kanghwa",
     "wof:parent_id":890476309,
     "wof:placetype":"locality",

--- a/data/102/026/443/102026443.geojson
+++ b/data/102/026/443/102026443.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Iksan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e700d197a6b02de0fd00e1a16a163a1",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         }
     ],
     "wof:id":102026443,
-    "wof:lastmodified":1566586190,
+    "wof:lastmodified":1582331595,
     "wof:name":"Iksan",
     "wof:parent_id":890476057,
     "wof:placetype":"locality",

--- a/data/102/026/447/102026447.geojson
+++ b/data/102/026/447/102026447.geojson
@@ -431,6 +431,9 @@
         "qs_pg:id":351265
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb6166a2f9bdc937a83518144ad1357a",
     "wof:hierarchy":[
         {
@@ -442,7 +445,7 @@
         }
     ],
     "wof:id":102026447,
-    "wof:lastmodified":1566586176,
+    "wof:lastmodified":1582331593,
     "wof:megacity":1,
     "wof:name":"Incheon",
     "wof:parent_id":1108746503,

--- a/data/102/026/449/102026449.geojson
+++ b/data/102/026/449/102026449.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Imsil County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1fa33931fa158ae4040513d9296ebd98",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":102026449,
-    "wof:lastmodified":1566586177,
+    "wof:lastmodified":1582331593,
     "wof:name":"Imsil",
     "wof:parent_id":890474645,
     "wof:placetype":"locality",

--- a/data/102/026/451/102026451.geojson
+++ b/data/102/026/451/102026451.geojson
@@ -211,6 +211,9 @@
         "wd:id":"Q42136"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"add7d61726e9d93ab02765ed7e6c2095",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":102026451,
-    "wof:lastmodified":1566586193,
+    "wof:lastmodified":1582331595,
     "wof:name":"Ich'\u014fn",
     "wof:parent_id":890475061,
     "wof:placetype":"locality",

--- a/data/102/026/453/102026453.geojson
+++ b/data/102/026/453/102026453.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Hwaseong, Gyeonggi"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73625ba7880c45017e83da2aa17b8b7f",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586182,
+    "wof:lastmodified":1582331593,
     "wof:name":"Hwaseong",
     "wof:parent_id":890476049,
     "wof:placetype":"locality",

--- a/data/102/026/455/102026455.geojson
+++ b/data/102/026/455/102026455.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Hwacheon County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d22dfd6f08db79018dcd9e758f9968ff",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":102026455,
-    "wof:lastmodified":1566586181,
+    "wof:lastmodified":1582331593,
     "wof:name":"Hwacheon",
     "wof:parent_id":890476187,
     "wof:placetype":"locality",

--- a/data/102/026/459/102026459.geojson
+++ b/data/102/026/459/102026459.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Hongcheon County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12e407572c2d4b0258dd97e43cad88fe",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":102026459,
-    "wof:lastmodified":1566586194,
+    "wof:lastmodified":1582331595,
     "wof:name":"Hongch\u2019\u014fn",
     "wof:parent_id":890475955,
     "wof:placetype":"locality",

--- a/data/102/026/463/102026463.geojson
+++ b/data/102/026/463/102026463.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Haenam County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"57204fe0ba5fcca2879920b262640311",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":102026463,
-    "wof:lastmodified":1566586180,
+    "wof:lastmodified":1582331593,
     "wof:name":"Haenam",
     "wof:parent_id":890475077,
     "wof:placetype":"locality",

--- a/data/102/026/467/102026467.geojson
+++ b/data/102/026/467/102026467.geojson
@@ -357,6 +357,9 @@
         "wk:page":"Chuncheon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2fff2ea4f3b69eee937c95cc0108b317",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586193,
+    "wof:lastmodified":1582331595,
     "wof:name":"Chuncheon",
     "wof:parent_id":890472419,
     "wof:placetype":"locality",

--- a/data/102/026/471/102026471.geojson
+++ b/data/102/026/471/102026471.geojson
@@ -361,6 +361,9 @@
         "wk:page":"Jeonju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37b6461b16f3d593e6f17d1b4be3721a",
     "wof:hierarchy":[
         {
@@ -375,7 +378,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586176,
+    "wof:lastmodified":1582331593,
     "wof:name":"Jeonju",
     "wof:parent_id":1108746469,
     "wof:placetype":"locality",

--- a/data/102/026/477/102026477.geojson
+++ b/data/102/026/477/102026477.geojson
@@ -335,6 +335,9 @@
         "wk:page":"Cheongju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbf9586a2221732767da2cf3cd79f093",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586178,
+    "wof:lastmodified":1582331593,
     "wof:name":"Cheongju",
     "wof:parent_id":890472255,
     "wof:placetype":"locality",

--- a/data/102/026/479/102026479.geojson
+++ b/data/102/026/479/102026479.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Cheonan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dcdcf03335b4253d43a2b74a2a92bd84",
     "wof:hierarchy":[
         {
@@ -223,7 +226,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586178,
+    "wof:lastmodified":1582331593,
     "wof:name":"Tenan",
     "wof:parent_id":1108746433,
     "wof:placetype":"locality",

--- a/data/102/026/481/102026481.geojson
+++ b/data/102/026/481/102026481.geojson
@@ -228,6 +228,9 @@
         "wk:page":"Jinju"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f83892ca20aacef5aeff7f6b8bbbd76f",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586191,
+    "wof:lastmodified":1582331595,
     "wof:name":"Chinju",
     "wof:parent_id":890475301,
     "wof:placetype":"locality",

--- a/data/102/026/483/102026483.geojson
+++ b/data/102/026/483/102026483.geojson
@@ -61,6 +61,9 @@
         "qs_pg:id":137043
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7f1b058741c1350776b772fb99bd4ef",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586178,
+    "wof:lastmodified":1582331593,
     "wof:name":"Chinhae",
     "wof:parent_id":890475303,
     "wof:placetype":"locality",

--- a/data/102/026/485/102026485.geojson
+++ b/data/102/026/485/102026485.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Jincheon County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e08c8226b52a38adc01d8695a73480e",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":102026485,
-    "wof:lastmodified":1566586177,
+    "wof:lastmodified":1582331593,
     "wof:name":"Chinch'\u014fn",
     "wof:parent_id":890476185,
     "wof:placetype":"locality",

--- a/data/102/026/487/102026487.geojson
+++ b/data/102/026/487/102026487.geojson
@@ -57,6 +57,9 @@
         "qs_pg:id":1031702
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec8408279c86a4df3dc48a90e76207ea",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":102026487,
-    "wof:lastmodified":1566586192,
+    "wof:lastmodified":1582331595,
     "wof:name":"\uc9c4\uc548\uad70",
     "wof:parent_id":890472257,
     "wof:placetype":"locality",

--- a/data/102/026/489/102026489.geojson
+++ b/data/102/026/489/102026489.geojson
@@ -318,6 +318,9 @@
         "qs_pg:id":1121126
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc216c79ae1adfd429b82ee074f2c205",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586192,
+    "wof:lastmodified":1582331595,
     "wof:name":"Jeju",
     "wof:parent_id":890473039,
     "wof:placetype":"locality",

--- a/data/102/026/495/102026495.geojson
+++ b/data/102/026/495/102026495.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Changwon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d6fb10c9118f9d9d0b80dc7502cb4aa",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586194,
+    "wof:lastmodified":1582331595,
     "wof:name":"Changwon",
     "wof:parent_id":1108746539,
     "wof:placetype":"locality",

--- a/data/102/026/497/102026497.geojson
+++ b/data/102/026/497/102026497.geojson
@@ -109,6 +109,9 @@
         "wk:page":"Jangsu County"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29dcb3d709a9c34bae2113ca359c234f",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":102026497,
-    "wof:lastmodified":1566586180,
+    "wof:lastmodified":1582331593,
     "wof:name":"Changsu",
     "wof:parent_id":890475719,
     "wof:placetype":"locality",

--- a/data/102/026/501/102026501.geojson
+++ b/data/102/026/501/102026501.geojson
@@ -202,6 +202,9 @@
         "qs_pg:id":351281
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f2e35cd54591812d643440d2dcee0f3f",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586188,
+    "wof:lastmodified":1582331594,
     "wof:name":"Anyang",
     "wof:parent_id":1108746411,
     "wof:placetype":"locality",

--- a/data/102/026/503/102026503.geojson
+++ b/data/102/026/503/102026503.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Anseong"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"713b97a4fcc3a932a8c11aad065bafe7",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586175,
+    "wof:lastmodified":1582331592,
     "wof:name":"Anseong",
     "wof:parent_id":890474641,
     "wof:placetype":"locality",

--- a/data/102/026/505/102026505.geojson
+++ b/data/102/026/505/102026505.geojson
@@ -354,6 +354,9 @@
         "qs_pg:id":1220408
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1f1053b18f70ea9e19e7e9afed468b4",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586173,
+    "wof:lastmodified":1582331592,
     "wof:name":"Ansan",
     "wof:parent_id":1108746407,
     "wof:placetype":"locality",

--- a/data/102/026/507/102026507.geojson
+++ b/data/102/026/507/102026507.geojson
@@ -336,6 +336,9 @@
         "wk:page":"Andong"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"548baa0933f442b6d33c5b170e49a397",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
         }
     ],
     "wof:id":102026507,
-    "wof:lastmodified":1566586189,
+    "wof:lastmodified":1582331594,
     "wof:name":"Andong",
     "wof:parent_id":890473215,
     "wof:placetype":"locality",

--- a/data/102/026/521/102026521.geojson
+++ b/data/102/026/521/102026521.geojson
@@ -361,6 +361,9 @@
         "wd:id":"Q42108"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9093de60f039bf97e359f5c91d669f5a",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
         }
     ],
     "wof:id":102026521,
-    "wof:lastmodified":1566586184,
+    "wof:lastmodified":1582331594,
     "wof:megacity":1,
     "wof:name":"Seongnam",
     "wof:parent_id":1108746519,

--- a/data/102/026/525/102026525.geojson
+++ b/data/102/026/525/102026525.geojson
@@ -232,6 +232,9 @@
         "wd:id":"Q42084"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8eb3701f296dd124e97b93756fe4bffe",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586197,
+    "wof:lastmodified":1582331596,
     "wof:name":"Yanggok",
     "wof:parent_id":890474583,
     "wof:placetype":"locality",

--- a/data/102/026/537/102026537.geojson
+++ b/data/102/026/537/102026537.geojson
@@ -342,6 +342,9 @@
         "wd:id":"Q20927"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6cb57467b1528b30df2911749944f6e2",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586187,
+    "wof:lastmodified":1582331594,
     "wof:name":"T\u014fksan",
     "wof:parent_id":890476025,
     "wof:placetype":"locality",

--- a/data/102/026/545/102026545.geojson
+++ b/data/102/026/545/102026545.geojson
@@ -171,6 +171,9 @@
         "wd:id":"Q42103"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f959b9263f31c8e497a70d24b1a39371",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":102026545,
-    "wof:lastmodified":1566586186,
+    "wof:lastmodified":1582331594,
     "wof:name":"Seogwipo",
     "wof:parent_id":890474633,
     "wof:placetype":"locality",

--- a/data/102/026/595/102026595.geojson
+++ b/data/102/026/595/102026595.geojson
@@ -277,6 +277,9 @@
         "qs_pg:id":1111153
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fec5f5656dbb0e6b83188a0e9143a66b",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586173,
+    "wof:lastmodified":1582331592,
     "wof:name":"Ulsan",
     "wof:parent_id":890474681,
     "wof:placetype":"locality",

--- a/data/856/322/31/85632231.geojson
+++ b/data/856/322/31/85632231.geojson
@@ -1226,6 +1226,11 @@
     },
     "wof:country":"KR",
     "wof:country_alpha3":"KOR",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"57f91b4413eb1c9b13d5a76ad9de7b04",
     "wof:hierarchy":[
         {
@@ -1240,7 +1245,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586832,
+    "wof:lastmodified":1582331609,
     "wof:name":"South Korea",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/731/73/85673173.geojson
+++ b/data/856/731/73/85673173.geojson
@@ -372,6 +372,9 @@
         "wk:page":"North Chungcheong Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e3042faa460f0cf84d56c018c8ef0fc",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586830,
+    "wof:lastmodified":1582331607,
     "wof:name":"North Chungcheong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/77/85673177.geojson
+++ b/data/856/731/77/85673177.geojson
@@ -474,6 +474,9 @@
         "wk:page":"Incheon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddb366944287ff62d93a9f3a315f789e",
     "wof:hierarchy":[
         {
@@ -489,7 +492,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586831,
+    "wof:lastmodified":1582331607,
     "wof:name":"Incheon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/81/85673181.geojson
+++ b/data/856/731/81/85673181.geojson
@@ -346,6 +346,9 @@
         "wk:page":"Gangwon Province (South Korea)"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b4e8422ec955295284cd3513b2452cb",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586830,
+    "wof:lastmodified":1582331607,
     "wof:name":"Gangwon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/85/85673185.geojson
+++ b/data/856/731/85/85673185.geojson
@@ -716,6 +716,9 @@
         102026327
     ],
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19ebc655dd303b75f7be6f2cdd289b2f",
     "wof:hierarchy":[
         {
@@ -731,7 +734,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586831,
+    "wof:lastmodified":1582331608,
     "wof:name":"Seoul",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/91/85673191.geojson
+++ b/data/856/731/91/85673191.geojson
@@ -370,6 +370,9 @@
         "wk:page":"Gyeonggi Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9a88b587042d55d2c5f72dfd3b159f8",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586831,
+    "wof:lastmodified":1582331607,
     "wof:name":"Gyeonggi",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/95/85673195.geojson
+++ b/data/856/731/95/85673195.geojson
@@ -342,6 +342,9 @@
         "wk:page":"North Jeolla Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3e202bc067a8dde47500c509b7b9ab3",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586829,
+    "wof:lastmodified":1582331607,
     "wof:name":"North Jeolla",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/99/85673199.geojson
+++ b/data/856/731/99/85673199.geojson
@@ -432,6 +432,9 @@
         "wd:id":"Q41283"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d2f0f75010148ce8244b4f0cae07c7e",
     "wof:hierarchy":[
         {
@@ -447,7 +450,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586831,
+    "wof:lastmodified":1582331607,
     "wof:name":"Gwangju",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/03/85673203.geojson
+++ b/data/856/732/03/85673203.geojson
@@ -365,6 +365,9 @@
         "wk:page":"South Chungcheong Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"420b078fd13c24272bad5a9565ab1263",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586838,
+    "wof:lastmodified":1582331611,
     "wof:name":"South Chungcheong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/07/85673207.geojson
+++ b/data/856/732/07/85673207.geojson
@@ -434,6 +434,9 @@
         "wk:page":"Daejeon"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63e5a8c7b010a175ea56934d0f6138e8",
     "wof:hierarchy":[
         {
@@ -449,7 +452,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586843,
+    "wof:lastmodified":1582331614,
     "wof:name":"Daejeon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/13/85673213.geojson
+++ b/data/856/732/13/85673213.geojson
@@ -437,6 +437,9 @@
         "wk:page":"Daegu"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c206845c3bbbcc88c1fc3092ac9313a8",
     "wof:hierarchy":[
         {
@@ -452,7 +455,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586845,
+    "wof:lastmodified":1582331615,
     "wof:name":"Daegu",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/15/85673215.geojson
+++ b/data/856/732/15/85673215.geojson
@@ -372,6 +372,9 @@
         "wk:page":"South Gyeongsang Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0bf41c45085ea9ba166a2fa66078177",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586844,
+    "wof:lastmodified":1582331614,
     "wof:name":"South Gyeongsang",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/19/85673219.geojson
+++ b/data/856/732/19/85673219.geojson
@@ -344,6 +344,9 @@
         "wk:page":"South Jeolla Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2d784d0144bea2643b1e12a796f80d3",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586840,
+    "wof:lastmodified":1582331612,
     "wof:name":"South Jeolla",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/27/85673227.geojson
+++ b/data/856/732/27/85673227.geojson
@@ -503,6 +503,9 @@
         "wk:page":"Busan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a86970080e1ff84a529833f519ea4031",
     "wof:hierarchy":[
         {
@@ -518,7 +521,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586839,
+    "wof:lastmodified":1582331612,
     "wof:name":"Busan",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/31/85673231.geojson
+++ b/data/856/732/31/85673231.geojson
@@ -408,6 +408,9 @@
         "wk:page":"Ulsan"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d17e4bbd0e7ad9c9dcc7f5f7275599e",
     "wof:hierarchy":[
         {
@@ -423,7 +426,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586844,
+    "wof:lastmodified":1582331614,
     "wof:name":"Ulsan",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/33/85673233.geojson
+++ b/data/856/732/33/85673233.geojson
@@ -372,6 +372,9 @@
         "wk:page":"North Gyeongsang Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"100ed767bf564c5d6931f06a445891ec",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586839,
+    "wof:lastmodified":1582331612,
     "wof:name":"North Gyeongsang",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/37/85673237.geojson
+++ b/data/856/732/37/85673237.geojson
@@ -390,6 +390,9 @@
         "wk:page":"Jeju Province"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b134a7b7c7602a97a2e9847178eb5fb",
     "wof:hierarchy":[
         {
@@ -405,7 +408,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586844,
+    "wof:lastmodified":1582331614,
     "wof:name":"Jeju",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/43/85673243.geojson
+++ b/data/856/732/43/85673243.geojson
@@ -169,6 +169,9 @@
         "unlc:id":"KR-50"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89bd5a336beb19e32dfcdc536e24313a",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566586843,
+    "wof:lastmodified":1582331614,
     "wof:name":"Sejong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/859/254/11/85925411.geojson
+++ b/data/859/254/11/85925411.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":204119
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d31aa79d331bc09d9c8bc4d388137584",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc591\uc9c0\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/19/85925419.geojson
+++ b/data/859/254/19/85925419.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1115418
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26b80c14dc4d3d1028f024219d03285d",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc2e0\ucd0c\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/25/85925425.geojson
+++ b/data/859/254/25/85925425.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1112764
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b63c90419e2cba619f3dabb8ab6b76a6",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uace0\ub4f1\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/33/85925433.geojson
+++ b/data/859/254/33/85925433.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":32104
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce2d06325e6ec7518643b9f040487195",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc131\ub0a8\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/41/85925441.geojson
+++ b/data/859/254/41/85925441.geojson
@@ -78,6 +78,9 @@
         "qs:id":358490
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"292b048f4926b0054943960c6e84fd55",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1534379374,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc740\ud5892\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/45/85925445.geojson
+++ b/data/859/254/45/85925445.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1103991
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"877ae2b9dd6893da9b8fac0de61f8d23",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc0c1\ub300\uc6d01\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/49/85925449.geojson
+++ b/data/859/254/49/85925449.geojson
@@ -71,6 +71,10 @@
         "wd:id":"Q2647272"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"533e1b309b97e5349d9fa794c856a369",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ud558\ub300\uc6d0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/67/85925467.geojson
+++ b/data/859/254/67/85925467.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":216134
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e010b2544e7802f52424e028d4299bb3",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586827,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc11c\ud6041\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/89/85925489.geojson
+++ b/data/859/254/89/85925489.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":483969
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a74e07be70ecfc02592bda49ae88898f",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc57c\ud0d13\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/05/85925505.geojson
+++ b/data/859/255/05/85925505.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":358504
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bcfabae1b351bc96a7336d9747e27183",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586829,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uad6c\ubbf8\ub3d9",
     "wof:parent_id":102026469,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/79/85925579.geojson
+++ b/data/859/255/79/85925579.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1293197
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ba4a66e0819dbaf7af1dfa315774fe4",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586829,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ud638\uacc43\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/47/85925647.geojson
+++ b/data/859/256/47/85925647.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":488672
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98199cca0ec5fe6e409416e89c22db82",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586827,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc0ac2\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/85/85925685.geojson
+++ b/data/859/256/85/85925685.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q17453794"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49288bd73dd1bd6430bf40903333bdb6",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586827,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ub300\ubd80\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/03/85925703.geojson
+++ b/data/859/257/03/85925703.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":210218
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4088d4ab9953df018b54600984a538a4",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uace0\uc591\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/59/85925759.geojson
+++ b/data/859/257/59/85925759.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":230185
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9373bd4aff09a746f7668afc69952ec3",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uace0\ubd09\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/87/85925787.geojson
+++ b/data/859/257/87/85925787.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1316024
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ddd03fa119f2d939386b1f0808f0d12f",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ud3ec\uace1\uc74d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/91/85925791.geojson
+++ b/data/859/257/91/85925791.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":467661
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0268335250d04d88ef0c1bb607ad44d",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ubaa8\ud604\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/95/85925795.geojson
+++ b/data/859/257/95/85925795.geojson
@@ -88,6 +88,10 @@
         "qs_pg:id":772292
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b8b17b6cf2e405851ad813438fd8528",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc774\ub3d9\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/01/85925801.geojson
+++ b/data/859/258/01/85925801.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1287138
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e02092e744e814b21db9b9b1f8206ad",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc6d0\uc0bc\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/05/85925805.geojson
+++ b/data/859/258/05/85925805.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1287110
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83affe169adc768e7c9b685e0918cd92",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc591\uc9c0\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/09/85925809.geojson
+++ b/data/859/258/09/85925809.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1191632
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6db36c821a1b863415ccc307b8c7341c",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc5ed\uc0bc\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/21/85925821.geojson
+++ b/data/859/258/21/85925821.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":230186
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"670341a84d45a9d4843a2f6bc2bd3c74",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc0c1\uac08\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/29/85925829.geojson
+++ b/data/859/258/29/85925829.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293357
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9346ac122ff737c8e12c23269ae31c08",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uad6c\uc131\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/39/85925839.geojson
+++ b/data/859/258/39/85925839.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1001194
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63bb44bb07456c44df497ac050c04981",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc5b4\uc815\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/57/85925857.geojson
+++ b/data/859/258/57/85925857.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":884050
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd5695b84592e881413943ddba0efdc5",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc2e0\ubd09\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/61/85925861.geojson
+++ b/data/859/258/61/85925861.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":182721
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4828d256443bd6e700d22b368538d09",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc8fd\uc8041\ub3d9",
     "wof:parent_id":102026469,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/69/85925869.geojson
+++ b/data/859/258/69/85925869.geojson
@@ -66,6 +66,10 @@
         "wd:id":"Q16181763"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e5e035c2a1393d0044443a7173df556",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ub3d9\ucc9c\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/85/85925885.geojson
+++ b/data/859/258/85/85925885.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1223729
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a265c9fc258d6d344d4f9a573415f6f2",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uc6b0\uc554\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/91/85925891.geojson
+++ b/data/859/258/91/85925891.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1287264
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"90c8a466b0cc8a3865aa9c383acc9d4a",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc6a9\ub2f4.\uba85\uc554.\uc0b0\uc131\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/95/85925895.geojson
+++ b/data/859/258/95/85925895.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1287273
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"252ba1fe0ba3b94b944dc8cdd6d4dc7a",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc0ac\uc9c1\uc81c1\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/99/85925899.geojson
+++ b/data/859/258/99/85925899.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1287283
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"485dcfe6516993b8ef174f629c42f3ef",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586826,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc218\uace11\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/03/85925903.geojson
+++ b/data/859/259/03/85925903.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":773985
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e2e5f7afd4bd277773d2fa6b4ed22a2",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ubcf5\ub3002\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/57/85925957.geojson
+++ b/data/859/259/57/85925957.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":250253
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccfca9554aacf0e80d4ad49278fc8f9e",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc870\ucd0c\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/67/85925967.geojson
+++ b/data/859/259/67/85925967.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":210262
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd873352f6f629871b2bd8a0ee0ce60b",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uae30\uc7a5\uc74d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/71/85925971.geojson
+++ b/data/859/259/71/85925971.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1328427
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5201ea613fc3b0f8dd0fbdb6cb976533",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc77c\uad11\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/75/85925975.geojson
+++ b/data/859/259/75/85925975.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":338209
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fadf528389a5b35717aed870183b390b",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ub17c\uacf5\uc74d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/83/85925983.geojson
+++ b/data/859/259/83/85925983.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":236621
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ceeb60a7f06493431d9bd07b010b0ae6",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uac15\ud654\uc74d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/87/85925987.geojson
+++ b/data/859/259/87/85925987.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1064739
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4847c2be6a80cb923730dc7e0f22c25f",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc120\uc6d0\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/91/85925991.geojson
+++ b/data/859/259/91/85925991.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1328428
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2dcd2b59031e9755d4dd6a6b304939b3",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ubd88\uc740\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/95/85925995.geojson
+++ b/data/859/259/95/85925995.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":427071
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"48a063f30917304b7f0bc41305212422",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc591\ub3c4\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/05/85926005.geojson
+++ b/data/859/260/05/85926005.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":427069
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0755082dd9a51101e2b9d45e77a21850",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc1a1\ud574\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/07/85926007.geojson
+++ b/data/859/260/07/85926007.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":427073
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"545edbc07a1f1bf6d341acec0be8bbe4",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uad50\ub3d9\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/11/85926011.geojson
+++ b/data/859/260/11/85926011.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1318781
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23495ac56d8badbf6439b0ae3cdd3170",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc0bc\uc0b0\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/29/85926029.geojson
+++ b/data/859/260/29/85926029.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":427077
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"786f71508a206616ad30a7810c9b6e79",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc11c\uc0dd\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/35/85926035.geojson
+++ b/data/859/260/35/85926035.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1294599
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7497323a352a95147fb7b43d3ef652ab",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc0c1\ubd81\uba74",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/93/85926193.geojson
+++ b/data/859/261/93/85926193.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":204120
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d83bb756363154b8effaae20f7768a60",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586824,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc0c1\uacc4\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/31/85926431.geojson
+++ b/data/859/264/31/85926431.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1294605
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b38658b42872f9a4214589cb8308d5c1",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586829,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ub454\ucd0c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/81/85926481.geojson
+++ b/data/859/264/81/85926481.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":224152
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0dc279a97babfb1c298a60c3eb0b7f5",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ub3d9\uc0bc\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/95/85926495.geojson
+++ b/data/859/264/95/85926495.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294627
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7815882037ef9183c0f59fa61b850dc5",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ub2f9\uac10\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/63/85926563.geojson
+++ b/data/859/265/63/85926563.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":985738
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7e0a981bc296aba1de1e8ace32fee78",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ud558\ub2e8\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/77/85926577.geojson
+++ b/data/859/265/77/85926577.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1186177
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"21a86c48694d7aa8d3fd65d6be98ceea",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586828,
+    "wof:lastmodified":1582331606,
     "wof:name":"\ub300\uc800\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/69/85926669.geojson
+++ b/data/859/266/69/85926669.geojson
@@ -66,6 +66,9 @@
         "gp:id":28835253
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5790f6511e97e2ab33b24df26dc53b01",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uace0\uc0b0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/55/85926755.geojson
+++ b/data/859/267/55/85926755.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1294636
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a98b6d1a65b28a58494a186965319823",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uac80\ub2e8\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/99/85926799.geojson
+++ b/data/859/267/99/85926799.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":775500
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9dea75092779bc1e0bb5ba5331de4645",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586825,
+    "wof:lastmodified":1582331605,
     "wof:name":"\ubc95\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/29/85927029.geojson
+++ b/data/859/270/29/85927029.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":230197
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9cc8f638a0e2fa254c3074f8c2b3d5dc",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586827,
+    "wof:lastmodified":1582331606,
     "wof:name":"\uacf5\ud56d\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/33/85927233.geojson
+++ b/data/859/272/33/85927233.geojson
@@ -67,6 +67,9 @@
         "gp:id":28995100
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33adda3455398d0f7503b29098ad7d38",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\ub0a8\uc0b0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/37/85927237.geojson
+++ b/data/859/272/37/85927237.geojson
@@ -63,6 +63,10 @@
         "wd:id":"Q16170621"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f82ca51647a9521c15fbbb214f32af5",
     "wof:hierarchy":[
         {
@@ -78,7 +82,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uae08\uc131\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/51/85927251.geojson
+++ b/data/859/272/51/85927251.geojson
@@ -67,6 +67,9 @@
         "gp:id":28995109
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0347484c8e1fd8ce8eb9cf431f1cf581",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uc0bc\ub77d\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/67/85927267.geojson
+++ b/data/859/272/67/85927267.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":55620
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eae0d1728b2c215be9ae5bc8693180f7",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\ud574\uc548\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/99/85927299.geojson
+++ b/data/859/272/99/85927299.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":55631
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34478e8359429e4dba6e65ca394e9647",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uc74d\ub0b4\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/21/85927321.geojson
+++ b/data/859/273/21/85927321.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":213947
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94bcedab3a23283127364c687616badc",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uc5f0\uc548\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/45/85927345.geojson
+++ b/data/859/273/45/85927345.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1128592
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab66ec0d4591308d6c5f5e50c995b48b",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586822,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uc601\uc885\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/29/85927429.geojson
+++ b/data/859/274/29/85927429.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1256937
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74f8ee4fc54e4c376c34464c1f376860",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586821,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uac74\uad6d\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/81/85927481.geojson
+++ b/data/859/274/81/85927481.geojson
@@ -108,6 +108,9 @@
         "wk:page":"Saunik Island"
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43bae5cb4124811894b09192dbe8e9f7",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586821,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uc9c4\uc7a0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/93/85927493.geojson
+++ b/data/859/274/93/85927493.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":427215
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac84374e76fb9af6b5bfce2b6a3c20d8",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586821,
+    "wof:lastmodified":1582331604,
     "wof:name":"\uad6c\uc989\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/33/85927533.geojson
+++ b/data/859/275/33/85927533.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":233563
     },
     "wof:country":"KR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0d56da99b1ec362d82475c9c48dd084",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566586823,
+    "wof:lastmodified":1582331605,
     "wof:name":"\uc77c\uc0b0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/472/085/890472085.geojson
+++ b/data/890/472/085/890472085.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5fc193442e1b9331d4ecac4215c59a03",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890472085,
-    "wof:lastmodified":1566589704,
+    "wof:lastmodified":1582331659,
     "wof:name":"Yeonje",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/091/890472091.geojson
+++ b/data/890/472/091/890472091.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fdd74be15a212901e0eab9fd8abfa2c",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890472091,
-    "wof:lastmodified":1566589705,
+    "wof:lastmodified":1582331659,
     "wof:name":"Haeundae",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/093/890472093.geojson
+++ b/data/890/472/093/890472093.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdb79675203f43b4d00a9455a798c392",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890472093,
-    "wof:lastmodified":1566589730,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gangseo",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/095/890472095.geojson
+++ b/data/890/472/095/890472095.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a160755c11a2b37c9e006724f23add60",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890472095,
-    "wof:lastmodified":1566589727,
+    "wof:lastmodified":1582331661,
     "wof:name":"Dong",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/472/097/890472097.geojson
+++ b/data/890/472/097/890472097.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"311cb81eecd50742ba56af730f5b20d3",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890472097,
-    "wof:lastmodified":1566589708,
+    "wof:lastmodified":1582331660,
     "wof:name":"Geumjeong",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/099/890472099.geojson
+++ b/data/890/472/099/890472099.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e48880d4b823749ac98af094edb2efd2",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890472099,
-    "wof:lastmodified":1566589707,
+    "wof:lastmodified":1582331660,
     "wof:name":"Gijang",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/181/890472181.geojson
+++ b/data/890/472/181/890472181.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be31d29f292f5cdca08c90d6d53dd90e",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890472181,
-    "wof:lastmodified":1566589714,
+    "wof:lastmodified":1582331660,
     "wof:name":"Hongseong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/185/890472185.geojson
+++ b/data/890/472/185/890472185.geojson
@@ -274,6 +274,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b31ebcc800815f3834745c05b100d4cb",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
         }
     ],
     "wof:id":890472185,
-    "wof:lastmodified":1566589735,
+    "wof:lastmodified":1582331661,
     "wof:name":"Nam",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/472/187/890472187.geojson
+++ b/data/890/472/187/890472187.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de10952cade61c93833b4a915a1d5105",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890472187,
-    "wof:lastmodified":1566589710,
+    "wof:lastmodified":1582331660,
     "wof:name":"Gwanak",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/189/890472189.geojson
+++ b/data/890/472/189/890472189.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf359ceb1c31efecbe95ed52aaa3cb5c",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":890472189,
-    "wof:lastmodified":1566589711,
+    "wof:lastmodified":1582331660,
     "wof:name":"Jindo",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/247/890472247.geojson
+++ b/data/890/472/247/890472247.geojson
@@ -234,6 +234,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77293195febf9fa60a2b869b75f91eb2",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         }
     ],
     "wof:id":890472247,
-    "wof:lastmodified":1566589724,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gwangyang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/251/890472251.geojson
+++ b/data/890/472/251/890472251.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e31ea82e07ac1e680d8d117f1fb4af5",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890472251,
-    "wof:lastmodified":1566589708,
+    "wof:lastmodified":1582331660,
     "wof:name":"Gumi",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/253/890472253.geojson
+++ b/data/890/472/253/890472253.geojson
@@ -295,6 +295,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5de77b9fdcfa13fecb70352f1137ea91",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":890472253,
-    "wof:lastmodified":1566589727,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gwangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/255/890472255.geojson
+++ b/data/890/472/255/890472255.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"246755ebb1e26f648077931c49abe489",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":890472255,
-    "wof:lastmodified":1566589730,
+    "wof:lastmodified":1582331661,
     "wof:name":"Chungju",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/257/890472257.geojson
+++ b/data/890/472/257/890472257.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c68ff336dc0b9b6c96dd79765e60c56",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890472257,
-    "wof:lastmodified":1566589705,
+    "wof:lastmodified":1582331659,
     "wof:name":"Jinan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/472/259/890472259.geojson
+++ b/data/890/472/259/890472259.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf43d0d3a34b22abed8d84feb6ba0198",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890472259,
-    "wof:lastmodified":1566589705,
+    "wof:lastmodified":1582331660,
     "wof:name":"Wando",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/273/890472273.geojson
+++ b/data/890/472/273/890472273.geojson
@@ -275,6 +275,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053888,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0edcc6688d75a526ae128f81542110f",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":890472273,
-    "wof:lastmodified":1566589702,
+    "wof:lastmodified":1582331659,
     "wof:name":"Seo",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/472/293/890472293.geojson
+++ b/data/890/472/293/890472293.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c7e7024b4c60baf818bc7d28d25464f",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890472293,
-    "wof:lastmodified":1566589708,
+    "wof:lastmodified":1582331660,
     "wof:name":"Gwangjin",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/295/890472295.geojson
+++ b/data/890/472/295/890472295.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af2a56454dcd5d236bf8619a29940606",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890472295,
-    "wof:lastmodified":1566589706,
+    "wof:lastmodified":1582331660,
     "wof:name":"Nowon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/297/890472297.geojson
+++ b/data/890/472/297/890472297.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8bf984e78be066bb5c6ef34e80bf939a",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890472297,
-    "wof:lastmodified":1566589729,
+    "wof:lastmodified":1582331661,
     "wof:name":"Seongbuk",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/299/890472299.geojson
+++ b/data/890/472/299/890472299.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c432c84515f08f62566e24076f0eb395",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890472299,
-    "wof:lastmodified":1566589730,
+    "wof:lastmodified":1582331661,
     "wof:name":"Yangcheon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/301/890472301.geojson
+++ b/data/890/472/301/890472301.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d5efdfa6d904235fcf2dfd66e45f0bb",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890472301,
-    "wof:lastmodified":1566589699,
+    "wof:lastmodified":1582331659,
     "wof:name":"Geumcheon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/323/890472323.geojson
+++ b/data/890/472/323/890472323.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053890,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2406611fe34c6dc64dd8d74058087a8",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":890472323,
-    "wof:lastmodified":1566589712,
+    "wof:lastmodified":1582331660,
     "wof:name":"Naju",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/333/890472333.geojson
+++ b/data/890/472/333/890472333.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053895,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f2d3fd629fdbb423fd5e27dc93940ff",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":890472333,
-    "wof:lastmodified":1566589721,
+    "wof:lastmodified":1582331661,
     "wof:name":"Boeun",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/345/890472345.geojson
+++ b/data/890/472/345/890472345.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08b7ed1bd2e63d0de6e56ffe9e442cce",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":890472345,
-    "wof:lastmodified":1566589731,
+    "wof:lastmodified":1582331661,
     "wof:name":"Sangju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/363/890472363.geojson
+++ b/data/890/472/363/890472363.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28a30afe850f5073acda33c1ac940824",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890472363,
-    "wof:lastmodified":1566589700,
+    "wof:lastmodified":1582331659,
     "wof:name":"Muan",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/377/890472377.geojson
+++ b/data/890/472/377/890472377.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fd6539d43e73cc4e390bc2ade724faf",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890472377,
-    "wof:lastmodified":1566589711,
+    "wof:lastmodified":1582331660,
     "wof:name":"Inje",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/472/405/890472405.geojson
+++ b/data/890/472/405/890472405.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"010b33216baefac28e91b2ed43663b9d",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890472405,
-    "wof:lastmodified":1566589727,
+    "wof:lastmodified":1582331661,
     "wof:name":"Miryang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/413/890472413.geojson
+++ b/data/890/472/413/890472413.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2499d218bad6cd1cec6b78b31aa1648",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":890472413,
-    "wof:lastmodified":1566589703,
+    "wof:lastmodified":1582331659,
     "wof:name":"Gongju",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/417/890472417.geojson
+++ b/data/890/472/417/890472417.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"933d3d7faa71ccacb3abd78ed0e7f190",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890472417,
-    "wof:lastmodified":1566589723,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gapyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/419/890472419.geojson
+++ b/data/890/472/419/890472419.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85774a2f76d03f45467ee819dac8a959",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":890472419,
-    "wof:lastmodified":1566589722,
+    "wof:lastmodified":1582331661,
     "wof:name":"Chuncheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/472/425/890472425.geojson
+++ b/data/890/472/425/890472425.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b55f82f66166edf088cdc4f6e65dbd3",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890472425,
-    "wof:lastmodified":1566589702,
+    "wof:lastmodified":1582331659,
     "wof:name":"Damyang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/439/890472439.geojson
+++ b/data/890/472/439/890472439.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"739b677fe684f858725e81d1f2a9ada5",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890472439,
-    "wof:lastmodified":1566589705,
+    "wof:lastmodified":1582331659,
     "wof:name":"Sancheong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/443/890472443.geojson
+++ b/data/890/472/443/890472443.geojson
@@ -207,6 +207,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"534f5b09fdbcb4baf07309316c92289f",
     "wof:hierarchy":[
         {
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":890472443,
-    "wof:lastmodified":1566589723,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gyeongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/445/890472445.geojson
+++ b/data/890/472/445/890472445.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30635d9729d1bde2d7c2f20af6cbfb8b",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":890472445,
-    "wof:lastmodified":1566589726,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gimpo",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/449/890472449.geojson
+++ b/data/890/472/449/890472449.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e05fbef1a8bd2339ae07617b82756050",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890472449,
-    "wof:lastmodified":1566589702,
+    "wof:lastmodified":1582331659,
     "wof:name":"Namdong",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/472/469/890472469.geojson
+++ b/data/890/472/469/890472469.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9e1fc7caaf2a6f68534726cd4c6b91f",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":890472469,
-    "wof:lastmodified":1566589726,
+    "wof:lastmodified":1582331661,
     "wof:name":"Hamyang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/515/890472515.geojson
+++ b/data/890/472/515/890472515.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053902,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"732ff902dc9ef53572317dc8fdedb086",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890472515,
-    "wof:lastmodified":1566589734,
+    "wof:lastmodified":1582331661,
     "wof:name":"Gyeryong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/589/890472589.geojson
+++ b/data/890/472/589/890472589.geojson
@@ -173,6 +173,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053910,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0201bdfd2b99ed9dc8a479e2af823e8",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":890472589,
-    "wof:lastmodified":1566589716,
+    "wof:lastmodified":1582331660,
     "wof:name":"Gwangmyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/595/890472595.geojson
+++ b/data/890/472/595/890472595.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053910,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bba0dc642f4d42eb63176b83a05d06e",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890472595,
-    "wof:lastmodified":1566589698,
+    "wof:lastmodified":1582331659,
     "wof:name":"Boryeong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/599/890472599.geojson
+++ b/data/890/472/599/890472599.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053910,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2f4dc0443d89164b6dfd222e0ac7030",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":890472599,
-    "wof:lastmodified":1566589718,
+    "wof:lastmodified":1582331660,
     "wof:name":"Danyang",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/895/890472895.geojson
+++ b/data/890/472/895/890472895.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053930,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e1c1f72314aaacd366b85f2752573ab",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890472895,
-    "wof:lastmodified":1566589705,
+    "wof:lastmodified":1582331659,
     "wof:name":"Seodaemun",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/985/890472985.geojson
+++ b/data/890/472/985/890472985.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053934,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc992b9cb9e8c4d58ded4589768ab314",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890472985,
-    "wof:lastmodified":1566589714,
+    "wof:lastmodified":1582331660,
     "wof:name":"Muju",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/473/007/890473007.geojson
+++ b/data/890/473/007/890473007.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"699dc0f2e4ee63c88f3e145a49b324ea",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":890473007,
-    "wof:lastmodified":1566589748,
+    "wof:lastmodified":1582331662,
     "wof:name":"Suseong",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/473/031/890473031.geojson
+++ b/data/890/473/031/890473031.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3687d2fe0b9d411deb66b780aaf2e0a",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":890473031,
-    "wof:lastmodified":1566589749,
+    "wof:lastmodified":1582331662,
     "wof:name":"Boseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/037/890473037.geojson
+++ b/data/890/473/037/890473037.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41f364cc1fd4cbe1e4e3f90f0b844f89",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":890473037,
-    "wof:lastmodified":1566589751,
+    "wof:lastmodified":1582331663,
     "wof:name":"Goheung",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/039/890473039.geojson
+++ b/data/890/473/039/890473039.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4c1b0f676fdeb2962b1ee8417cf955e",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890473039,
-    "wof:lastmodified":1566589752,
+    "wof:lastmodified":1582331663,
     "wof:name":"Jeju",
     "wof:parent_id":85673237,
     "wof:placetype":"county",

--- a/data/890/473/043/890473043.geojson
+++ b/data/890/473/043/890473043.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67c955be477a6cdb73ee56fb35e03980",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":890473043,
-    "wof:lastmodified":1566589765,
+    "wof:lastmodified":1582331664,
     "wof:name":"Gwacheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/175/890473175.geojson
+++ b/data/890/473/175/890473175.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47dc6a834990cc7b4a20c34a50950bed",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890473175,
-    "wof:lastmodified":1566589755,
+    "wof:lastmodified":1582331663,
     "wof:name":"Goryeong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/177/890473177.geojson
+++ b/data/890/473/177/890473177.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7fda95b86a4ab987938b8faad8bb581",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890473177,
-    "wof:lastmodified":1566589773,
+    "wof:lastmodified":1582331664,
     "wof:name":"Hapcheon",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/179/890473179.geojson
+++ b/data/890/473/179/890473179.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93c28470a711e52e6e0bea7cd9ecd74d",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":890473179,
-    "wof:lastmodified":1566589775,
+    "wof:lastmodified":1582331664,
     "wof:name":"Gimcheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/183/890473183.geojson
+++ b/data/890/473/183/890473183.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2fa404fdf6d09750aadea1f8755bc6d",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":890473183,
-    "wof:lastmodified":1566589774,
+    "wof:lastmodified":1582331664,
     "wof:name":"Wonju",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/189/890473189.geojson
+++ b/data/890/473/189/890473189.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf0f733bceda5bd9b065117026694372",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":890473189,
-    "wof:lastmodified":1566589754,
+    "wof:lastmodified":1582331663,
     "wof:name":"Taebaek",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/191/890473191.geojson
+++ b/data/890/473/191/890473191.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8aa7c62eb509225bdadb237f20ddca80",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890473191,
-    "wof:lastmodified":1566589758,
+    "wof:lastmodified":1582331663,
     "wof:name":"Seongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/193/890473193.geojson
+++ b/data/890/473/193/890473193.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b2dd4fbc8e4a7c5f9732d47cb508c6e",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":890473193,
-    "wof:lastmodified":1566589740,
+    "wof:lastmodified":1582331662,
     "wof:name":"Siheung",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/197/890473197.geojson
+++ b/data/890/473/197/890473197.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc6c7508d626c9b767e5c93bd03c8feb",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890473197,
-    "wof:lastmodified":1566589760,
+    "wof:lastmodified":1582331663,
     "wof:name":"Gwangsan",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/473/201/890473201.geojson
+++ b/data/890/473/201/890473201.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053943,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3ca710031b299f3d6fc3fe46d3a3345",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":890473201,
-    "wof:lastmodified":1566589769,
+    "wof:lastmodified":1582331664,
     "wof:name":"Mapo",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/215/890473215.geojson
+++ b/data/890/473/215/890473215.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053944,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"897751e90d0972774a69f06c6c2552eb",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":890473215,
-    "wof:lastmodified":1566589763,
+    "wof:lastmodified":1582331664,
     "wof:name":"Andong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/219/890473219.geojson
+++ b/data/890/473/219/890473219.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b44b90c6f17e4c8a525989ae6a382fd5",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890473219,
-    "wof:lastmodified":1566589745,
+    "wof:lastmodified":1582331662,
     "wof:name":"Yeosu",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/223/890473223.geojson
+++ b/data/890/473/223/890473223.geojson
@@ -173,6 +173,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31ce03885c97ac6c179e0f0b4367c39e",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":890473223,
-    "wof:lastmodified":1566589763,
+    "wof:lastmodified":1582331664,
     "wof:name":"Jongno",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/229/890473229.geojson
+++ b/data/890/473/229/890473229.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ba780188f4b9289c962dd5622aa447b",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890473229,
-    "wof:lastmodified":1566589741,
+    "wof:lastmodified":1582331662,
     "wof:name":"Yeonggwang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/231/890473231.geojson
+++ b/data/890/473/231/890473231.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0236ad37398fc2bb5bfea33cf58a9792",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890473231,
-    "wof:lastmodified":1566589766,
+    "wof:lastmodified":1582331664,
     "wof:name":"Yeongdeungpo",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/235/890473235.geojson
+++ b/data/890/473/235/890473235.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68cbabaf3309acdea04bd3902fd04b27",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890473235,
-    "wof:lastmodified":1566589748,
+    "wof:lastmodified":1582331662,
     "wof:name":"Gangbuk",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/237/890473237.geojson
+++ b/data/890/473/237/890473237.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053945,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d34e67ab8b3cf3b2c3a19286d14564b",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890473237,
-    "wof:lastmodified":1566589770,
+    "wof:lastmodified":1582331664,
     "wof:name":"Hwasun",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/253/890473253.geojson
+++ b/data/890/473/253/890473253.geojson
@@ -137,6 +137,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ba7992a024d31ebc75c1fc92f0d8b50",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":890473253,
-    "wof:lastmodified":1566589768,
+    "wof:lastmodified":1582331664,
     "wof:name":"Seongdong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/255/890473255.geojson
+++ b/data/890/473/255/890473255.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053946,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"457770fd925561c6a9b5fd5668f22231",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890473255,
-    "wof:lastmodified":1566589771,
+    "wof:lastmodified":1582331664,
     "wof:name":"Songpa",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/289/890473289.geojson
+++ b/data/890/473/289/890473289.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053947,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5522f3be3a08a14e965ca1bbf0c77ec",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890473289,
-    "wof:lastmodified":1566589744,
+    "wof:lastmodified":1582331662,
     "wof:name":"Jangseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/295/890473295.geojson
+++ b/data/890/473/295/890473295.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053947,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"945915737a35b088a8789c12b46aeaba",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":890473295,
-    "wof:lastmodified":1566589748,
+    "wof:lastmodified":1582331662,
     "wof:name":"Hanam",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/315/890473315.geojson
+++ b/data/890/473/315/890473315.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a61b4f99eedc4638a2a8833c4642b68",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":890473315,
-    "wof:lastmodified":1566589755,
+    "wof:lastmodified":1582331663,
     "wof:name":"Mokpo",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/319/890473319.geojson
+++ b/data/890/473/319/890473319.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a11b8e7d33406e199792c385c9a982e",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890473319,
-    "wof:lastmodified":1566589775,
+    "wof:lastmodified":1582331664,
     "wof:name":"Seocho",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/321/890473321.geojson
+++ b/data/890/473/321/890473321.geojson
@@ -273,6 +273,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28f47af17d1ef0652c800243d315b3a8",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":890473321,
-    "wof:lastmodified":1566589776,
+    "wof:lastmodified":1582331664,
     "wof:name":"Buk",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/473/335/890473335.geojson
+++ b/data/890/473/335/890473335.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee069de48559949c7b6e25585d45f46c",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":890473335,
-    "wof:lastmodified":1566589759,
+    "wof:lastmodified":1582331663,
     "wof:name":"Osan",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/345/890473345.geojson
+++ b/data/890/473/345/890473345.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053949,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e74474574ee132aab3b8edc59129517d",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890473345,
-    "wof:lastmodified":1566589773,
+    "wof:lastmodified":1582331664,
     "wof:name":"Geumsan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/473/363/890473363.geojson
+++ b/data/890/473/363/890473363.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c858c256f2101f33035f68d66f277e7",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890473363,
-    "wof:lastmodified":1566589740,
+    "wof:lastmodified":1582331662,
     "wof:name":"Yeongwol",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/385/890473385.geojson
+++ b/data/890/473/385/890473385.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053951,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56c144d1495a7b21705f1d976b7e060f",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890473385,
-    "wof:lastmodified":1566589755,
+    "wof:lastmodified":1582331663,
     "wof:name":"Cheongwon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/473/483/890473483.geojson
+++ b/data/890/473/483/890473483.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053954,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6bd86bc09369ac578135fc3fcdeea76c",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890473483,
-    "wof:lastmodified":1566589744,
+    "wof:lastmodified":1582331662,
     "wof:name":"Gangdong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/489/890473489.geojson
+++ b/data/890/473/489/890473489.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053954,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bd8898bb61a295b7f2e75864b277f23",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890473489,
-    "wof:lastmodified":1566589766,
+    "wof:lastmodified":1582331664,
     "wof:name":"Sacheon",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/513/890473513.geojson
+++ b/data/890/473/513/890473513.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053955,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d758ec0339331e427afaf48b36d079aa",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":890473513,
-    "wof:lastmodified":1566589773,
+    "wof:lastmodified":1582331664,
     "wof:name":"Jeongseon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/525/890473525.geojson
+++ b/data/890/473/525/890473525.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053955,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f561432a37a3fd742a2fa7ff2faa0b4",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":890473525,
-    "wof:lastmodified":1566589774,
+    "wof:lastmodified":1582331664,
     "wof:name":"Buyeo",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/473/531/890473531.geojson
+++ b/data/890/473/531/890473531.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db837a911d2196c0df14ba6577aa8843",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890473531,
-    "wof:lastmodified":1566589760,
+    "wof:lastmodified":1582331663,
     "wof:name":"Gimje",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/473/533/890473533.geojson
+++ b/data/890/473/533/890473533.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e33081317ffea8d4a2df66b3df0d93b2",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":890473533,
-    "wof:lastmodified":1566589736,
+    "wof:lastmodified":1582331662,
     "wof:name":"Dongdaemun",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/547/890473547.geojson
+++ b/data/890/473/547/890473547.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e74da310d15a142d68696f66ae6c87e",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890473547,
-    "wof:lastmodified":1566589772,
+    "wof:lastmodified":1582331664,
     "wof:name":"Jangheung",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/555/890473555.geojson
+++ b/data/890/473/555/890473555.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b676f6359d25259cf6b9c33bfb9e2120",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890473555,
-    "wof:lastmodified":1566589758,
+    "wof:lastmodified":1582331663,
     "wof:name":"Ongjin",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/473/557/890473557.geojson
+++ b/data/890/473/557/890473557.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdde99d7f233d5536789aa75d82c6a64",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":890473557,
-    "wof:lastmodified":1566589739,
+    "wof:lastmodified":1582331662,
     "wof:name":"Gongju",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/559/890473559.geojson
+++ b/data/890/473/559/890473559.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a0604257d2efa88fd242092c64f7455",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":890473559,
-    "wof:lastmodified":1566589738,
+    "wof:lastmodified":1582331662,
     "wof:name":"Yeongdong",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/473/561/890473561.geojson
+++ b/data/890/473/561/890473561.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c333b97774b1934438ef4c582f4222f",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890473561,
-    "wof:lastmodified":1566589738,
+    "wof:lastmodified":1582331662,
     "wof:name":"Eunpyeong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/621/890473621.geojson
+++ b/data/890/473/621/890473621.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"baac8e8b13d860f71a2d44b76fac2eb5",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890473621,
-    "wof:lastmodified":1566589743,
+    "wof:lastmodified":1582331662,
     "wof:name":"Changnyeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/623/890473623.geojson
+++ b/data/890/473/623/890473623.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6daff3c78ead81b2bc5855abe10e459c",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890473623,
-    "wof:lastmodified":1566589764,
+    "wof:lastmodified":1582331664,
     "wof:name":"Hoengseong",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/661/890473661.geojson
+++ b/data/890/473/661/890473661.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053961,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb096e51b451038d3dfaf20ebec5b056",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890473661,
-    "wof:lastmodified":1566589750,
+    "wof:lastmodified":1582331663,
     "wof:name":"Gangjin",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/713/890473713.geojson
+++ b/data/890/473/713/890473713.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053962,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f52944f944b58264fadca859eca622e3",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890473713,
-    "wof:lastmodified":1566589753,
+    "wof:lastmodified":1582331663,
     "wof:name":"Yeongyang",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/945/890473945.geojson
+++ b/data/890/473/945/890473945.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053971,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0855e2ccbf2195b1e335258c8e699428",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":890473945,
-    "wof:lastmodified":1566589774,
+    "wof:lastmodified":1582331664,
     "wof:name":"Goesan",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/474/133/890474133.geojson
+++ b/data/890/474/133/890474133.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053978,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"474ba20368a8c0358d6f113f4a881223",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890474133,
-    "wof:lastmodified":1566589780,
+    "wof:lastmodified":1582331665,
     "wof:name":"Daedeok",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/890/474/443/890474443.geojson
+++ b/data/890/474/443/890474443.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053989,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fdd156baba12a4bee41e6f1eed470d1",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":890474443,
-    "wof:lastmodified":1566589802,
+    "wof:lastmodified":1582331666,
     "wof:name":"Nonsan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/447/890474447.geojson
+++ b/data/890/474/447/890474447.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053989,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13b8e53e8e2ce8c9d0c225b9a2854c3d",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
         }
     ],
     "wof:id":890474447,
-    "wof:lastmodified":1566589782,
+    "wof:lastmodified":1582331665,
     "wof:name":"Gangnam",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/474/479/890474479.geojson
+++ b/data/890/474/479/890474479.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053991,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83794221e33ed29e2ecf459e95a3fc18",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890474479,
-    "wof:lastmodified":1566589785,
+    "wof:lastmodified":1582331665,
     "wof:name":"Bonghwa",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/513/890474513.geojson
+++ b/data/890/474/513/890474513.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053992,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"745054c9f63ff26cd9032941b20d54c6",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890474513,
-    "wof:lastmodified":1566589813,
+    "wof:lastmodified":1582331666,
     "wof:name":"Haman",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/515/890474515.geojson
+++ b/data/890/474/515/890474515.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053992,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c329b97744997a18906e1dc8b32079bc",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":890474515,
-    "wof:lastmodified":1566589816,
+    "wof:lastmodified":1582331666,
     "wof:name":"Geoje",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/581/890474581.geojson
+++ b/data/890/474/581/890474581.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053995,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"784c7b0619f5e6be06a0ee276e3b3647",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":890474581,
-    "wof:lastmodified":1566589793,
+    "wof:lastmodified":1582331665,
     "wof:name":"Tongyeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/583/890474583.geojson
+++ b/data/890/474/583/890474583.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053995,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1dbb582ceed47864ee125a82959b9ab6",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":890474583,
-    "wof:lastmodified":1566589814,
+    "wof:lastmodified":1582331666,
     "wof:name":"Namyangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/585/890474585.geojson
+++ b/data/890/474/585/890474585.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053995,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"155aa5b5092719f9614903abb0f4dcd0",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":890474585,
-    "wof:lastmodified":1566589811,
+    "wof:lastmodified":1582331666,
     "wof:name":"Gunpo",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/591/890474591.geojson
+++ b/data/890/474/591/890474591.geojson
@@ -172,6 +172,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dcb0bc6155f556fb7d7468e0c1f51f13",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":890474591,
-    "wof:lastmodified":1566589800,
+    "wof:lastmodified":1582331666,
     "wof:name":"Guri",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/597/890474597.geojson
+++ b/data/890/474/597/890474597.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe072a642dff474597e8eb5ff8d7d5a5",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":890474597,
-    "wof:lastmodified":1566589798,
+    "wof:lastmodified":1582331666,
     "wof:name":"Yangsan",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/599/890474599.geojson
+++ b/data/890/474/599/890474599.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7b44027c28f085aa526ee3c24bf2e6d",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":890474599,
-    "wof:lastmodified":1566589797,
+    "wof:lastmodified":1582331666,
     "wof:name":"Yuseong",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/890/474/617/890474617.geojson
+++ b/data/890/474/617/890474617.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053996,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"586bac2d504cb4139503dda8b9676bb1",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":890474617,
-    "wof:lastmodified":1566589783,
+    "wof:lastmodified":1582331665,
     "wof:name":"Saha",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/474/629/890474629.geojson
+++ b/data/890/474/629/890474629.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"287bcb9be630a270c594b2c42c0908be",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890474629,
-    "wof:lastmodified":1566589786,
+    "wof:lastmodified":1582331665,
     "wof:name":"Uiryeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/631/890474631.geojson
+++ b/data/890/474/631/890474631.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28dfb6e62dad775e6eabc9ed645f9244",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890474631,
-    "wof:lastmodified":1566589810,
+    "wof:lastmodified":1582331666,
     "wof:name":"Uiseong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/633/890474633.geojson
+++ b/data/890/474/633/890474633.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a5094869676f922183133a2aa40ec5d",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":890474633,
-    "wof:lastmodified":1566589787,
+    "wof:lastmodified":1582331665,
     "wof:name":"Seogwipo",
     "wof:parent_id":85673237,
     "wof:placetype":"county",

--- a/data/890/474/635/890474635.geojson
+++ b/data/890/474/635/890474635.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3803672b846845664affde7ba3ed82bb",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":890474635,
-    "wof:lastmodified":1566589790,
+    "wof:lastmodified":1582331665,
     "wof:name":"Suncheon",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/474/637/890474637.geojson
+++ b/data/890/474/637/890474637.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8788a222e0e52284693451a44d71cd83",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":890474637,
-    "wof:lastmodified":1566589807,
+    "wof:lastmodified":1582331666,
     "wof:name":"Uiwang",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/639/890474639.geojson
+++ b/data/890/474/639/890474639.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa6c8cec650a9c76bd70ddf979a0fe6f",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890474639,
-    "wof:lastmodified":1566589807,
+    "wof:lastmodified":1582331666,
     "wof:name":"Uljin",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/641/890474641.geojson
+++ b/data/890/474/641/890474641.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"656168a7d7b94e1e309a8d95a9738f9e",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":890474641,
-    "wof:lastmodified":1566589804,
+    "wof:lastmodified":1582331666,
     "wof:name":"Anseong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/645/890474645.geojson
+++ b/data/890/474/645/890474645.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f91410fbaed9d8ddb7dbc89376ad570",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890474645,
-    "wof:lastmodified":1566589784,
+    "wof:lastmodified":1582331665,
     "wof:name":"Imsil",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/474/647/890474647.geojson
+++ b/data/890/474/647/890474647.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b26dfe042964b78d9890bf6169fd72b",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890474647,
-    "wof:lastmodified":1566589802,
+    "wof:lastmodified":1582331666,
     "wof:name":"Gyeyang",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/474/649/890474649.geojson
+++ b/data/890/474/649/890474649.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469053998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2988096309ab2b6a34a60c3aab31624",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890474649,
-    "wof:lastmodified":1566589801,
+    "wof:lastmodified":1582331666,
     "wof:name":"Cheongyang",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/681/890474681.geojson
+++ b/data/890/474/681/890474681.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"432a7bb4998a2f0c2c492d23db68b055",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890474681,
-    "wof:lastmodified":1566589782,
+    "wof:lastmodified":1582331665,
     "wof:name":"Ulju",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/890/474/683/890474683.geojson
+++ b/data/890/474/683/890474683.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a845fdf0093d55c59085ef46a70c5d4",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890474683,
-    "wof:lastmodified":1566589805,
+    "wof:lastmodified":1582331666,
     "wof:name":"Wanju",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/474/685/890474685.geojson
+++ b/data/890/474/685/890474685.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3467922709ad820e5bd23453cd5cfd3",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890474685,
-    "wof:lastmodified":1566589802,
+    "wof:lastmodified":1582331666,
     "wof:name":"Yanggu",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/474/687/890474687.geojson
+++ b/data/890/474/687/890474687.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12af1e5733ec0a279856a945cad4338e",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890474687,
-    "wof:lastmodified":1566589785,
+    "wof:lastmodified":1582331665,
     "wof:name":"Yeongam",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/474/695/890474695.geojson
+++ b/data/890/474/695/890474695.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054001,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba9408c0ca5a924431425e89b4e1199d",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890474695,
-    "wof:lastmodified":1566589791,
+    "wof:lastmodified":1582331665,
     "wof:name":"Yesan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/963/890474963.geojson
+++ b/data/890/474/963/890474963.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b904124be467ec88db423baf7065053",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":890474963,
-    "wof:lastmodified":1566589781,
+    "wof:lastmodified":1582331665,
     "wof:name":"Cheongsong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/965/890474965.geojson
+++ b/data/890/474/965/890474965.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46887944f482054e7f1e7768c532395b",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":890474965,
-    "wof:lastmodified":1566589779,
+    "wof:lastmodified":1582331665,
     "wof:name":"Guro",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/474/969/890474969.geojson
+++ b/data/890/474/969/890474969.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00b2d465034ce105272b99791e7bb7b1",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890474969,
-    "wof:lastmodified":1566589799,
+    "wof:lastmodified":1582331666,
     "wof:name":"Gunwi",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/033/890475033.geojson
+++ b/data/890/475/033/890475033.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054016,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"750505c7305d01151d75b7c40bac982e",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":890475033,
-    "wof:lastmodified":1566589687,
+    "wof:lastmodified":1582331658,
     "wof:name":"Jecheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/475/035/890475035.geojson
+++ b/data/890/475/035/890475035.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054016,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b710cefa2906090682ef56949c6fd792",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":890475035,
-    "wof:lastmodified":1566589685,
+    "wof:lastmodified":1582331658,
     "wof:name":"Seosan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/475/041/890475041.geojson
+++ b/data/890/475/041/890475041.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054016,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c83c6f9036741eb62e31b1a407002aff",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890475041,
-    "wof:lastmodified":1566589657,
+    "wof:lastmodified":1582331657,
     "wof:name":"Sinan",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/061/890475061.geojson
+++ b/data/890/475/061/890475061.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f11833fedd3ad0fac7d98babdcecb970",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":890475061,
-    "wof:lastmodified":1566589686,
+    "wof:lastmodified":1582331658,
     "wof:name":"Icheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/069/890475069.geojson
+++ b/data/890/475/069/890475069.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f9c4a6c4ee8bb1ab0d0da4df7853839",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890475069,
-    "wof:lastmodified":1566589688,
+    "wof:lastmodified":1582331658,
     "wof:name":"Gurye",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/073/890475073.geojson
+++ b/data/890/475/073/890475073.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b4e8b3f473b27fe3867f81645c3cc02",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890475073,
-    "wof:lastmodified":1566589679,
+    "wof:lastmodified":1582331658,
     "wof:name":"Hadong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/077/890475077.geojson
+++ b/data/890/475/077/890475077.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e01b4c6f6ff913cc7ee96cf4d615a00c",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":890475077,
-    "wof:lastmodified":1566589659,
+    "wof:lastmodified":1582331657,
     "wof:name":"Haenam",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/279/890475279.geojson
+++ b/data/890/475/279/890475279.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"99c6b29e5327c4f68f9bedb189ce0c00",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":890475279,
-    "wof:lastmodified":1566589680,
+    "wof:lastmodified":1582331658,
     "wof:name":"Chilgok",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/295/890475295.geojson
+++ b/data/890/475/295/890475295.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58a3e862e693c010b141bd7aac04fe9b",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":890475295,
-    "wof:lastmodified":1566589663,
+    "wof:lastmodified":1582331657,
     "wof:name":"Yongsan",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/475/297/890475297.geojson
+++ b/data/890/475/297/890475297.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbc7c18abbf20c2fb8a83813d3796d19",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":890475297,
-    "wof:lastmodified":1566589689,
+    "wof:lastmodified":1582331658,
     "wof:name":"Jung",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/475/299/890475299.geojson
+++ b/data/890/475/299/890475299.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"401f02c68faa322fb0a0c4830b307011",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":890475299,
-    "wof:lastmodified":1566589689,
+    "wof:lastmodified":1582331658,
     "wof:name":"Uijeongbu",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/301/890475301.geojson
+++ b/data/890/475/301/890475301.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9db682fbda00e846804faa9641af3b76",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":890475301,
-    "wof:lastmodified":1566589652,
+    "wof:lastmodified":1582331656,
     "wof:name":"Jinju",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/303/890475303.geojson
+++ b/data/890/475/303/890475303.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054027,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"552967dee662fed8cd3ed793f286f6dd",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":890475303,
-    "wof:lastmodified":1566589675,
+    "wof:lastmodified":1582331658,
     "wof:name":"Gimhae",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/307/890475307.geojson
+++ b/data/890/475/307/890475307.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054028,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c70d61493c3b9cf4f54071ddde21efc",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890475307,
-    "wof:lastmodified":1566589649,
+    "wof:lastmodified":1582331656,
     "wof:name":"Yeongdeok",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/313/890475313.geojson
+++ b/data/890/475/313/890475313.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054028,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1376538d3843f10f4e54ac37855d91fe",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890475313,
-    "wof:lastmodified":1566589672,
+    "wof:lastmodified":1582331657,
     "wof:name":"Yangpyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/315/890475315.geojson
+++ b/data/890/475/315/890475315.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054028,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98a73be261e232e566152bd4367d5df1",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890475315,
-    "wof:lastmodified":1566589670,
+    "wof:lastmodified":1582331657,
     "wof:name":"Yecheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/319/890475319.geojson
+++ b/data/890/475/319/890475319.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054028,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d25b193f9866deb9aecdb5c5c06c9510",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":890475319,
-    "wof:lastmodified":1566589693,
+    "wof:lastmodified":1582331659,
     "wof:name":"Yeongcheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/321/890475321.geojson
+++ b/data/890/475/321/890475321.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054028,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e96ce49b4f13150eb62e5427276d7f4",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":890475321,
-    "wof:lastmodified":1566589693,
+    "wof:lastmodified":1582331659,
     "wof:name":"Yeongdo",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/475/357/890475357.geojson
+++ b/data/890/475/357/890475357.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054031,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4615ae4b43e488bd27f20471caea2e33",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":890475357,
-    "wof:lastmodified":1566589674,
+    "wof:lastmodified":1582331658,
     "wof:name":"Ulleung",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/391/890475391.geojson
+++ b/data/890/475/391/890475391.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054032,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfc46e10710a60e20dfe35b8a60a36b1",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":890475391,
-    "wof:lastmodified":1566589650,
+    "wof:lastmodified":1582331656,
     "wof:name":"Gokseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/397/890475397.geojson
+++ b/data/890/475/397/890475397.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054032,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c33ded711def17efe3fc7329ee55d10b",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890475397,
-    "wof:lastmodified":1566589654,
+    "wof:lastmodified":1582331656,
     "wof:name":"Gunsan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/429/890475429.geojson
+++ b/data/890/475/429/890475429.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054033,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79f235abdeebcad6e9f40950fad3ea54",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":890475429,
-    "wof:lastmodified":1566589682,
+    "wof:lastmodified":1582331658,
     "wof:name":"Yangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/465/890475465.geojson
+++ b/data/890/475/465/890475465.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054035,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"910f099df84a8e1d24372872430a84c5",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":890475465,
-    "wof:lastmodified":1566589667,
+    "wof:lastmodified":1582331657,
     "wof:name":"Goseong",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/467/890475467.geojson
+++ b/data/890/475/467/890475467.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054035,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d89b283b67fb8fc6419d8b7d8c23372",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":890475467,
-    "wof:lastmodified":1566589684,
+    "wof:lastmodified":1582331658,
     "wof:name":"Namhae",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/485/890475485.geojson
+++ b/data/890/475/485/890475485.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054036,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5c4776eddf7c82ecb856ce91dfd6d6a",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890475485,
-    "wof:lastmodified":1566589656,
+    "wof:lastmodified":1582331657,
     "wof:name":"Gochang",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/539/890475539.geojson
+++ b/data/890/475/539/890475539.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054040,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3070706d87f807393a7061b6299c398c",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":890475539,
-    "wof:lastmodified":1566589674,
+    "wof:lastmodified":1582331658,
     "wof:name":"Asan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/475/545/890475545.geojson
+++ b/data/890/475/545/890475545.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054040,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39b29ce25fd680990df0c0d2d672c4e9",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":890475545,
-    "wof:lastmodified":1566589672,
+    "wof:lastmodified":1582331658,
     "wof:name":"Okcheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/475/719/890475719.geojson
+++ b/data/890/475/719/890475719.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054047,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2391a2237df68ede65d8495b421fed4",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890475719,
-    "wof:lastmodified":1566589691,
+    "wof:lastmodified":1582331659,
     "wof:name":"Jangsu",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/757/890475757.geojson
+++ b/data/890/475/757/890475757.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054048,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f844a11d5ce57af197b48000b464dc34",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890475757,
-    "wof:lastmodified":1566589677,
+    "wof:lastmodified":1582331658,
     "wof:name":"Cheongdo",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/779/890475779.geojson
+++ b/data/890/475/779/890475779.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4913086538eebd2a03d2a93f797467c0",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":890475779,
-    "wof:lastmodified":1566589673,
+    "wof:lastmodified":1582331658,
     "wof:name":"Busanjin",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/475/783/890475783.geojson
+++ b/data/890/475/783/890475783.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f983c0370ab6cdc5eb95e99f9131c27",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":890475783,
-    "wof:lastmodified":1566589672,
+    "wof:lastmodified":1582331657,
     "wof:name":"Buan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/797/890475797.geojson
+++ b/data/890/475/797/890475797.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5b12f4c7d6f1452e8f01c3ac2ad5639",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":890475797,
-    "wof:lastmodified":1566589649,
+    "wof:lastmodified":1582331656,
     "wof:name":"Namwon",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/951/890475951.geojson
+++ b/data/890/475/951/890475951.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054056,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80732dd97fe0d223e347415a17a42c9c",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":890475951,
-    "wof:lastmodified":1566589677,
+    "wof:lastmodified":1582331658,
     "wof:name":"Jeongeup",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/955/890475955.geojson
+++ b/data/890/475/955/890475955.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054056,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"11fdf8a18ba27f956ed85d7bd554f77b",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":890475955,
-    "wof:lastmodified":1566589655,
+    "wof:lastmodified":1582331656,
     "wof:name":"Hongcheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/961/890475961.geojson
+++ b/data/890/475/961/890475961.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054056,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa83ed996c9ee775957dcc9d9494f1e1",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":890475961,
-    "wof:lastmodified":1566589674,
+    "wof:lastmodified":1582331658,
     "wof:name":"Dalseong",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/475/963/890475963.geojson
+++ b/data/890/475/963/890475963.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054056,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43f895e145faf2561430e26fa7474fa1",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":890475963,
-    "wof:lastmodified":1566589653,
+    "wof:lastmodified":1582331656,
     "wof:name":"Yangyang",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/965/890475965.geojson
+++ b/data/890/475/965/890475965.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054056,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6295e40b5722746d102ea3943d5becdb",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":890475965,
-    "wof:lastmodified":1566589651,
+    "wof:lastmodified":1582331656,
     "wof:name":"Yeoncheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/019/890476019.geojson
+++ b/data/890/476/019/890476019.geojson
@@ -137,6 +137,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054058,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77b38719e06ca843be84591165877174",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":890476019,
-    "wof:lastmodified":1566589643,
+    "wof:lastmodified":1582331655,
     "wof:name":"Geochang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/476/025/890476025.geojson
+++ b/data/890/476/025/890476025.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8bef82a09dd6bf07af789d8fcdd9ae0c",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":890476025,
-    "wof:lastmodified":1566589632,
+    "wof:lastmodified":1582331655,
     "wof:name":"Dalseo",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/476/035/890476035.geojson
+++ b/data/890/476/035/890476035.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b19eb55f660156fb62e0530b8987a8db",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":890476035,
-    "wof:lastmodified":1566589644,
+    "wof:lastmodified":1582331655,
     "wof:name":"Yeonsu",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/037/890476037.geojson
+++ b/data/890/476/037/890476037.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33102ecf3117281703b9249141765f4e",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":890476037,
-    "wof:lastmodified":1566589635,
+    "wof:lastmodified":1582331655,
     "wof:name":"Bupyeong",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/039/890476039.geojson
+++ b/data/890/476/039/890476039.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aec6750c4891ba72c00ba7583a338b7a",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":890476039,
-    "wof:lastmodified":1566589636,
+    "wof:lastmodified":1582331655,
     "wof:name":"Sasang",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/476/049/890476049.geojson
+++ b/data/890/476/049/890476049.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94ec38c8dd0f2fbfd3b105127979e912",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890476049,
-    "wof:lastmodified":1566589633,
+    "wof:lastmodified":1582331655,
     "wof:name":"Hwaseong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/051/890476051.geojson
+++ b/data/890/476/051/890476051.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0671df122be3dc1d3ee55652e4bc6bdd",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":890476051,
-    "wof:lastmodified":1566589646,
+    "wof:lastmodified":1582331656,
     "wof:name":"Paju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/053/890476053.geojson
+++ b/data/890/476/053/890476053.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75e8bfd7fc66a708e2bd7e6fe506ad42",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890476053,
-    "wof:lastmodified":1566589634,
+    "wof:lastmodified":1582331655,
     "wof:name":"Pocheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/055/890476055.geojson
+++ b/data/890/476/055/890476055.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7b13d27fe3e1b7ac9c87e65e9a338e9",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":890476055,
-    "wof:lastmodified":1566589635,
+    "wof:lastmodified":1582331655,
     "wof:name":"Sokcho",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/057/890476057.geojson
+++ b/data/890/476/057/890476057.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aaab070c32a142db9118e4c6bc35fe5d",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":890476057,
-    "wof:lastmodified":1566589645,
+    "wof:lastmodified":1582331656,
     "wof:name":"Iksan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/476/059/890476059.geojson
+++ b/data/890/476/059/890476059.geojson
@@ -292,6 +292,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b465d53e0781dd2eca2783e3e0b71034",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         }
     ],
     "wof:id":890476059,
-    "wof:lastmodified":1566589644,
+    "wof:lastmodified":1582331655,
     "wof:name":"Pyeongchang",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/061/890476061.geojson
+++ b/data/890/476/061/890476061.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054061,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"441c2033baccfcd38deb2cc3cc233fe5",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":890476061,
-    "wof:lastmodified":1566589644,
+    "wof:lastmodified":1582331655,
     "wof:name":"Pyeongtaek",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/169/890476169.geojson
+++ b/data/890/476/169/890476169.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6585646366d5da5a7199b4ea75f467c",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890476169,
-    "wof:lastmodified":1566589630,
+    "wof:lastmodified":1582331655,
     "wof:name":"Gangneung",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/175/890476175.geojson
+++ b/data/890/476/175/890476175.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cdeb7a411c85a378fcebd5c511b15b45",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890476175,
-    "wof:lastmodified":1566589637,
+    "wof:lastmodified":1582331655,
     "wof:name":"Sunchang",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/476/179/890476179.geojson
+++ b/data/890/476/179/890476179.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b86c82ce69977686587a22068ca2d7de",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":890476179,
-    "wof:lastmodified":1566589648,
+    "wof:lastmodified":1582331656,
     "wof:name":"Suyeong",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/476/183/890476183.geojson
+++ b/data/890/476/183/890476183.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8964e8d5e39e8c5e8512e6280fa43255",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":890476183,
-    "wof:lastmodified":1566589647,
+    "wof:lastmodified":1582331656,
     "wof:name":"Yeongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/185/890476185.geojson
+++ b/data/890/476/185/890476185.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6ceef31cdc709e121d28e548e361604",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890476185,
-    "wof:lastmodified":1566589649,
+    "wof:lastmodified":1582331656,
     "wof:name":"Jincheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/476/187/890476187.geojson
+++ b/data/890/476/187/890476187.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"574daa5412efc61a4224af2a98bb5a84",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":890476187,
-    "wof:lastmodified":1566589636,
+    "wof:lastmodified":1582331655,
     "wof:name":"Hwacheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/189/890476189.geojson
+++ b/data/890/476/189/890476189.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40d25e241c85d621931b3124569a7b54",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":890476189,
-    "wof:lastmodified":1566589636,
+    "wof:lastmodified":1582331655,
     "wof:name":"Samcheok",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/195/890476195.geojson
+++ b/data/890/476/195/890476195.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c57ab7088494da313fdac1f35f1e48ad",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":890476195,
-    "wof:lastmodified":1566589628,
+    "wof:lastmodified":1582331655,
     "wof:name":"Seocheon",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/476/201/890476201.geojson
+++ b/data/890/476/201/890476201.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ad9cd6cbba0b11a20b1cbf051a187c2",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":890476201,
-    "wof:lastmodified":1566589645,
+    "wof:lastmodified":1582331656,
     "wof:name":"Mungyeong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/211/890476211.geojson
+++ b/data/890/476/211/890476211.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054066,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0de52c55c1979e0ff7f3445d41fa0f66",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":890476211,
-    "wof:lastmodified":1566589630,
+    "wof:lastmodified":1582331655,
     "wof:name":"Gyeongsan",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/213/890476213.geojson
+++ b/data/890/476/213/890476213.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ca3edc1358dfc67d70a2a1e3cba0001",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":890476213,
-    "wof:lastmodified":1566589643,
+    "wof:lastmodified":1582331655,
     "wof:name":"Hampyeong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/476/241/890476241.geojson
+++ b/data/890/476/241/890476241.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054068,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8481dc51d3b941b97a1adbdca8533a9",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":890476241,
-    "wof:lastmodified":1566589641,
+    "wof:lastmodified":1582331655,
     "wof:name":"Dongducheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/243/890476243.geojson
+++ b/data/890/476/243/890476243.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054068,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef1d700c0b08975f83c804ea24069b2b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890476243,
-    "wof:lastmodified":1566589632,
+    "wof:lastmodified":1582331655,
     "wof:name":"Donghae",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/309/890476309.geojson
+++ b/data/890/476/309/890476309.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054071,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac52387513521432a51293e0807be046",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":890476309,
-    "wof:lastmodified":1566589627,
+    "wof:lastmodified":1582331654,
     "wof:name":"Ganghwa",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/313/890476313.geojson
+++ b/data/890/476/313/890476313.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"KR",
     "wof:created":1469054071,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"674344c0d7ed826053d3a9cf76376e1f",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":890476313,
-    "wof:lastmodified":1566589638,
+    "wof:lastmodified":1582331655,
     "wof:name":"Dongjak",
     "wof:parent_id":85673185,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.