### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/859/258/83/85925883.geojson
+++ b/data/859/258/83/85925883.geojson
@@ -12,11 +12,11 @@
     "gn:latitude":37.31639,
     "gn:longitude":127.07222,
     "iso:country":"KR",
-    "lbl:latitude":37.309531,
-    "lbl:longitude":127.079947,
+    "lbl:latitude":37.318669,
+    "lbl:longitude":127.067448,
     "lbl:max_zoom":18.0,
-    "mps:latitude":37.317999,
-    "mps:longitude":127.070926,
+    "mps:latitude":37.318669,
+    "mps:longitude":127.067448,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:is_funky":0,
@@ -63,13 +63,13 @@
         "quattroshapes_pg",
         "quattroshapes"
     ],
-    "src:lbl_centroid":"yerbashapes",
+    "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
+        85673191,
         102191569,
         85632231,
-        1108746545,
         102026263,
-        85673191
+        1108746545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -98,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1630713938,
+    "wof:lastmodified":1694320497,
     "wof:name":"Seongbok-dong",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.