### PR TITLE
kr concordances, placetype local, and more

### DIFF
--- a/data/110/874/638/3/1108746383.geojson
+++ b/data/110/874/638/3/1108746383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003754,
-    "geom:area_square_m":36874325.954324,
+    "geom:area_square_m":36874498.884209,
     "geom:bbox":"126.873255,37.354047,126.951193,37.45321",
     "geom:latitude":37.404781,
     "geom:longitude":126.912659,
@@ -68,10 +68,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31041"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154641,
-    "wof:geomhash":"c0981274b4794423f65f5c977dc0436e",
+    "wof:geomhash":"f906bc22b6126d81e0c8c5a4da4f0307",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1108746383,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Manan",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/638/5/1108746385.geojson
+++ b/data/110/874/638/5/1108746385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002219,
-    "geom:area_square_m":21760836.038305,
+    "geom:area_square_m":21760631.990174,
     "geom:bbox":"126.759327,37.503262,126.830721,37.554706",
     "geom:latitude":37.529066,
     "geom:longitude":126.794803,
@@ -142,11 +142,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"31053",
         "wd:id":"Q50192"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154641,
-    "wof:geomhash":"50b7db6dede4848306841245471d978c",
+    "wof:geomhash":"a659a279212b79ab087451f6b935a8eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -156,7 +158,7 @@
         }
     ],
     "wof:id":1108746385,
-    "wof:lastmodified":1690938307,
+    "wof:lastmodified":1695886625,
     "wof:name":"Ojeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/639/3/1108746393.geojson
+++ b/data/110/874/639/3/1108746393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003821,
-    "geom:area_square_m":38593038.340684,
+    "geom:area_square_m":38593154.147675,
     "geom:bbox":"128.991448,35.185144,129.061137,35.278753",
     "geom:latitude":35.230268,
     "geom:longitude":129.026244,
@@ -116,10 +116,13 @@
         85673227
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"21080"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154642,
-    "wof:geomhash":"e2f48fd93da110de93fe6f53931375d6",
+    "wof:geomhash":"88042300fe763bb2bd0b0c98db0e06f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1108746393,
-    "wof:lastmodified":1619481387,
+    "wof:lastmodified":1695886624,
     "wof:name":"Buk",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/110/874/639/5/1108746395.geojson
+++ b/data/110/874/639/5/1108746395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009337,
-    "geom:area_square_m":93487446.434852,
+    "geom:area_square_m":93487107.237145,
     "geom:bbox":"128.506705,35.876573,128.636565,35.989666",
     "geom:latitude":35.929696,
     "geom:longitude":128.579314,
@@ -116,10 +116,13 @@
         85673213
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"22050"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154642,
-    "wof:geomhash":"07dc81bdf6070e389705877ad433704c",
+    "wof:geomhash":"a2072bad743d7c0f64afc127a1fe9f9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1108746395,
-    "wof:lastmodified":1619481387,
+    "wof:lastmodified":1695886624,
     "wof:name":"Buk",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/110/874/639/9/1108746399.geojson
+++ b/data/110/874/639/9/1108746399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015624,
-    "geom:area_square_m":157059908.052187,
+    "geom:area_square_m":157059654.238592,
     "geom:bbox":"129.291319,35.520949,129.465424,35.683071",
     "geom:latitude":35.611475,
     "geom:longitude":129.381857,
@@ -116,10 +116,13 @@
         85673231
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"26040"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154643,
-    "wof:geomhash":"1d1448296d4f6ca559118329c446d7eb",
+    "wof:geomhash":"3994879b3d8b5fe7b034a8aadec219be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1108746399,
-    "wof:lastmodified":1619481387,
+    "wof:lastmodified":1695886624,
     "wof:name":"Buk",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/110/874/640/7/1108746407.geojson
+++ b/data/110/874/640/7/1108746407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009117,
-    "geom:area_square_m":89707824.594891,
+    "geom:area_square_m":89707495.123238,
     "geom:bbox":"126.379524,37.08036,126.848613,37.367665",
     "geom:latitude":37.276199,
     "geom:longitude":126.683539,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31092"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154707,
-    "wof:geomhash":"fc81c728aa02278d00fb25218f6f5c39",
+    "wof:geomhash":"a6d77ec270de0d1904270c9e0cdb440c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746407,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886767,
     "wof:name":"Danwon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/640/9/1108746409.geojson
+++ b/data/110/874/640/9/1108746409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006013,
-    "geom:area_square_m":59127589.037434,
+    "geom:area_square_m":59127376.044535,
     "geom:bbox":"126.814137,37.267944,126.940618,37.379679",
     "geom:latitude":37.316266,
     "geom:longitude":126.872878,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31091"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154707,
-    "wof:geomhash":"f8709b432783139985146176bc0e8258",
+    "wof:geomhash":"6e03a5bf14b0eb5b0b7e409a9dc8e440",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746409,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Sangnok",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/641/1/1108746411.geojson
+++ b/data/110/874/641/1/1108746411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002235,
-    "geom:area_square_m":21956232.731836,
+    "geom:area_square_m":21956305.003656,
     "geom:bbox":"126.927103,37.363251,126.984507,37.441586",
     "geom:latitude":37.40115,
     "geom:longitude":126.956577,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31042"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154708,
-    "wof:geomhash":"1964b701317545b0965539bb20ecb9df",
+    "wof:geomhash":"52c8deabfe5371113877eff624cc9b8b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746411,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886768,
     "wof:name":"Dongan",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/641/7/1108746417.geojson
+++ b/data/110/874/641/7/1108746417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001012,
-    "geom:area_square_m":9935325.793307,
+    "geom:area_square_m":9935250.010115,
     "geom:bbox":"126.766392,37.459165,126.830705,37.48887",
     "geom:latitude":37.475099,
     "geom:longitude":126.80189,
@@ -110,10 +110,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31052"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154708,
-    "wof:geomhash":"d0ab20246b9072a037ad540a1ba8717d",
+    "wof:geomhash":"9e3649bb67ef62c756f92cf03fbd3172",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":1108746417,
-    "wof:lastmodified":1619481386,
+    "wof:lastmodified":1695886624,
     "wof:name":"Sosa",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/641/9/1108746419.geojson
+++ b/data/110/874/641/9/1108746419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0022,
-    "geom:area_square_m":21585147.587047,
+    "geom:area_square_m":21585089.420728,
     "geom:bbox":"126.739238,37.480115,126.819578,37.522646",
     "geom:latitude":37.499989,
     "geom:longitude":126.77817,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31051"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154708,
-    "wof:geomhash":"8251ef7c1e426150b28902688d613811",
+    "wof:geomhash":"4ab0175bbf4e6717526c3476af4feaa1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746419,
-    "wof:lastmodified":1627522307,
+    "wof:lastmodified":1695886771,
     "wof:name":"Wonmi",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/642/7/1108746427.geojson
+++ b/data/110/874/642/7/1108746427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073649,
-    "geom:area_square_m":735205495.448713,
+    "geom:area_square_m":735205113.65237,
     "geom:bbox":"128.989048,36.016272,129.432052,36.333288",
     "geom:latitude":36.166435,
     "geom:longitude":129.235167,
@@ -116,10 +116,13 @@
         85673233
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"37012"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154709,
-    "wof:geomhash":"1ed56d83818ecbce90622fa504c0f3b4",
+    "wof:geomhash":"cda084b7ccd1d9fd24180c96f700003f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":1108746427,
-    "wof:lastmodified":1619481384,
+    "wof:lastmodified":1695886624,
     "wof:name":"Buk",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/110/874/643/1/1108746431.geojson
+++ b/data/110/874/643/1/1108746431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043865,
-    "geom:area_square_m":434508719.810598,
+    "geom:area_square_m":434508733.380732,
     "geom:bbox":"127.011769,36.624249,127.424489,36.894962",
     "geom:latitude":36.765142,
     "geom:longitude":127.223285,
@@ -65,10 +65,13 @@
         85673203
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"34011"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154709,
-    "wof:geomhash":"f48883ad4d0419f2e5d4f76145943090",
+    "wof:geomhash":"3fec481d81f43b5c37ec483e5ea0d8cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746431,
-    "wof:lastmodified":1627522304,
+    "wof:lastmodified":1695886769,
     "wof:name":"Dongnam",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/110/874/643/3/1108746433.geojson
+++ b/data/110/874/643/3/1108746433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019971,
-    "geom:area_square_m":197498666.351819,
+    "geom:area_square_m":197498453.791235,
     "geom:bbox":"127.076302,36.788205,127.286715,36.973753",
     "geom:latitude":36.893082,
     "geom:longitude":127.162256,
@@ -65,10 +65,13 @@
         85673203
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"34012"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154710,
-    "wof:geomhash":"3b40c497ece970831b70f9ccf81847d8",
+    "wof:geomhash":"f8c14dec652043b6f97eb2aa49aa15a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746433,
-    "wof:lastmodified":1627522307,
+    "wof:lastmodified":1695886771,
     "wof:name":"Seobuk",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/110/874/643/5/1108746435.geojson
+++ b/data/110/874/643/5/1108746435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008616,
-    "geom:area_square_m":85497078.714673,
+    "geom:area_square_m":85497171.550723,
     "geom:bbox":"127.366821,36.577524,127.500897,36.688405",
     "geom:latitude":36.633146,
     "geom:longitude":127.434517,
@@ -65,10 +65,13 @@
         85673173
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"33012"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154710,
-    "wof:geomhash":"6e463ae22d3dae7d19f74d71e6efc10d",
+    "wof:geomhash":"0c3320f9a28f8c0c99ee02315641e00f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746435,
-    "wof:lastmodified":1627522304,
+    "wof:lastmodified":1695886769,
     "wof:name":"Heungdeok",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/110/874/643/7/1108746437.geojson
+++ b/data/110/874/643/7/1108746437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006974,
-    "geom:area_square_m":69180517.704519,
+    "geom:area_square_m":69180571.409595,
     "geom:bbox":"127.448285,36.588977,127.562106,36.722646",
     "geom:latitude":36.652773,
     "geom:longitude":127.507403,
@@ -133,11 +133,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"33011",
         "wd:id":"Q50333"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154711,
-    "wof:geomhash":"1905beec922efc429854a03655339bb2",
+    "wof:geomhash":"1c027b4ebfe69030385b86f6e5125a29",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +149,7 @@
         }
     ],
     "wof:id":1108746437,
-    "wof:lastmodified":1690938304,
+    "wof:lastmodified":1695886624,
     "wof:name":"Sangdang",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/110/874/643/9/1108746439.geojson
+++ b/data/110/874/643/9/1108746439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059411,
-    "geom:area_square_m":587531923.456293,
+    "geom:area_square_m":587532040.256779,
     "geom:bbox":"126.417084,36.751456,126.861082,37.072029",
     "geom:latitude":36.891818,
     "geom:longitude":126.661741,
@@ -128,10 +128,13 @@
         85673203
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"34080"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154711,
-    "wof:geomhash":"3b74299def4827afbb5afc9ebb859400",
+    "wof:geomhash":"b66495747d9f982cc90d8f8616d9275c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":1108746439,
-    "wof:lastmodified":1619481384,
+    "wof:lastmodified":1695886624,
     "wof:name":"Dangjin",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/110/874/644/3/1108746443.geojson
+++ b/data/110/874/644/3/1108746443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002133,
-    "geom:area_square_m":20874201.868516,
+    "geom:area_square_m":20874236.897164,
     "geom:bbox":"127.009154,37.634852,127.060539,37.703621",
     "geom:latitude":37.670328,
     "geom:longitude":127.034095,
@@ -145,11 +145,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"11100",
         "wd:id":"Q50374"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154711,
-    "wof:geomhash":"626f2b0826a3daf7912b17da7f6728ed",
+    "wof:geomhash":"e938d168b8df6908281f2f410ed2627b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +161,7 @@
         }
     ],
     "wof:id":1108746443,
-    "wof:lastmodified":1690938304,
+    "wof:lastmodified":1695886624,
     "wof:name":"Dobong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/110/874/644/5/1108746445.geojson
+++ b/data/110/874/644/5/1108746445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018074,
-    "geom:area_square_m":180950369.705832,
+    "geom:area_square_m":180950614.371016,
     "geom:bbox":"128.604195,35.849375,128.768854,36.016681",
     "geom:latitude":35.935203,
     "geom:longitude":128.688189,
@@ -137,10 +137,13 @@
         85673213
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"22020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154711,
-    "wof:geomhash":"4142ac45d38110622f38c33405d93c1a",
+    "wof:geomhash":"df0ad5c00fe99d51b227e501796e4926",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":1108746445,
-    "wof:lastmodified":1636497468,
+    "wof:lastmodified":1695886736,
     "wof:name":"Dong",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/110/874/644/7/1108746447.geojson
+++ b/data/110/874/644/7/1108746447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01379,
-    "geom:area_square_m":137375749.169781,
+    "geom:area_square_m":137375774.724326,
     "geom:bbox":"127.418118,36.194386,127.555093,36.435375",
     "geom:latitude":36.326084,
     "geom:longitude":127.476142,
@@ -137,10 +137,13 @@
         85673207
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"25010"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154711,
-    "wof:geomhash":"deca8e2ec693e78175c1d15126cf28d5",
+    "wof:geomhash":"0b21fb6f9d320c35d4e431ccda6dadcd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":1108746447,
-    "wof:lastmodified":1636497468,
+    "wof:lastmodified":1695886736,
     "wof:name":"Dong",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/110/874/644/9/1108746449.geojson
+++ b/data/110/874/644/9/1108746449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000471,
-    "geom:area_square_m":4624893.864098,
+    "geom:area_square_m":4624904.301683,
     "geom:bbox":"126.609497,37.467762,126.660841,37.491752",
     "geom:latitude":37.480848,
     "geom:longitude":126.639029,
@@ -137,10 +137,13 @@
         85673177
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"23020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154712,
-    "wof:geomhash":"9032290b43b5342d0d46182562e62937",
+    "wof:geomhash":"739cf742f3d7b22a5d29bb28fd3c47b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":1108746449,
-    "wof:lastmodified":1636497468,
+    "wof:lastmodified":1695886736,
     "wof:name":"Dong",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/110/874/645/1/1108746451.geojson
+++ b/data/110/874/645/1/1108746451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003541,
-    "geom:area_square_m":35634018.507714,
+    "geom:area_square_m":35634054.667496,
     "geom:bbox":"129.394992,35.474556,129.460388,35.571491",
     "geom:latitude":35.526673,
     "geom:longitude":129.427957,
@@ -137,10 +137,13 @@
         85673231
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"26030"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154712,
-    "wof:geomhash":"ffc57efd394daa4f006030d92ac8d3ea",
+    "wof:geomhash":"7a1f5267be5cd0f37cb1a7881bb36871",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":1108746451,
-    "wof:lastmodified":1636497468,
+    "wof:lastmodified":1695886736,
     "wof:name":"Dong",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/110/874/645/3/1108746453.geojson
+++ b/data/110/874/645/3/1108746453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00174,
-    "geom:area_square_m":17581569.961494,
+    "geom:area_square_m":17581583.279154,
     "geom:bbox":"129.045135,35.184788,129.121941,35.231405",
     "geom:latitude":35.207376,
     "geom:longitude":129.081612,
@@ -65,10 +65,13 @@
         85673227
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"21060"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154712,
-    "wof:geomhash":"054d09cac606c7546b8a4cfc448b72df",
+    "wof:geomhash":"c4b4de50fb5034e79cc2fd2d0f8e2705",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746453,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886768,
     "wof:name":"Dongnae",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/110/874/645/5/1108746455.geojson
+++ b/data/110/874/645/5/1108746455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052256,
-    "geom:area_square_m":516192484.365936,
+    "geom:area_square_m":516192556.639639,
     "geom:bbox":"127.445861,36.835827,127.795378,37.155889",
     "geom:latitude":36.977342,
     "geom:longitude":127.614703,
@@ -165,11 +165,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"33370",
         "wd:id":"Q50315"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154712,
-    "wof:geomhash":"f312562a8eb7adad384687ba946e1859",
+    "wof:geomhash":"d0fd5f774a8a1138f3c6ff5ef388c78c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":1108746455,
-    "wof:lastmodified":1690938305,
+    "wof:lastmodified":1695886736,
     "wof:name":"Eumseong",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/110/874/645/7/1108746457.geojson
+++ b/data/110/874/645/7/1108746457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003711,
-    "geom:area_square_m":36379940.868846,
+    "geom:area_square_m":36379949.082226,
     "geom:bbox":"126.769815,37.5264,126.886731,37.602196",
     "geom:latitude":37.559813,
     "geom:longitude":126.823003,
@@ -138,11 +138,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"11160",
         "wd:id":"Q50192"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154713,
-    "wof:geomhash":"a4bbba3cec5e2a29eedf2f472d665b46",
+    "wof:geomhash":"7945dfffe54e2ceadbe35ff7b5a01240",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +154,7 @@
         }
     ],
     "wof:id":1108746457,
-    "wof:lastmodified":1690938304,
+    "wof:lastmodified":1695886624,
     "wof:name":"Gangseo",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/110/874/646/1/1108746461.geojson
+++ b/data/110/874/646/1/1108746461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053018,
-    "geom:area_square_m":536906920.998447,
+    "geom:area_square_m":536906783.419592,
     "geom:bbox":"128.103699,34.875416,128.50209,35.13328",
     "geom:latitude":35.016579,
     "geom:longitude":128.295203,
@@ -83,10 +83,13 @@
         85673215
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"38340"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154713,
-    "wof:geomhash":"1dbed0beb4caa361a4f0b7c5573d5d7a",
+    "wof:geomhash":"9d89bdf89b652fb2f37e6ee0c69a2c1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1108746461,
-    "wof:lastmodified":1627522304,
+    "wof:lastmodified":1695886769,
     "wof:name":"Goseong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/646/3/1108746463.geojson
+++ b/data/110/874/646/3/1108746463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016288,
-    "geom:area_square_m":159447715.759103,
+    "geom:area_square_m":159447626.608087,
     "geom:bbox":"126.774777,37.571305,126.997446,37.749075",
     "geom:latitude":37.657787,
     "geom:longitude":126.880718,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31101"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154713,
-    "wof:geomhash":"8793a78df5e50aaea41a8bac7d580011",
+    "wof:geomhash":"2a0aee144fadd45918fed12eddcbdaeb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746463,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886768,
     "wof:name":"Deogyang",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/646/5/1108746465.geojson
+++ b/data/110/874/646/5/1108746465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006069,
-    "geom:area_square_m":59392478.04444,
+    "geom:area_square_m":59392655.091084,
     "geom:bbox":"126.741328,37.627982,126.854144,37.735428",
     "geom:latitude":37.683039,
     "geom:longitude":126.799733,
@@ -68,10 +68,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31103"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154713,
-    "wof:geomhash":"84963bd65ba59cd5ddddf358bd318fed",
+    "wof:geomhash":"8d44ac94e3bbe21f3d704b6f5104950a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1108746465,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Ilsandong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/646/7/1108746467.geojson
+++ b/data/110/874/646/7/1108746467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004053,
-    "geom:area_square_m":39662517.115414,
+    "geom:area_square_m":39662455.410902,
     "geom:bbox":"126.67617,37.645033,126.78192,37.71",
     "geom:latitude":37.681915,
     "geom:longitude":126.732309,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31104"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154713,
-    "wof:geomhash":"0c3e95310d029ecb51385e0e89de33e8",
+    "wof:geomhash":"d6ec44e9dc3758a3869956c9eeb5bef2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746467,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Ilsanseo",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/646/9/1108746469.geojson
+++ b/data/110/874/646/9/1108746469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011234,
-    "geom:area_square_m":112580289.487736,
+    "geom:area_square_m":112580167.599543,
     "geom:bbox":"126.996468,35.796483,127.23408,35.904379",
     "geom:latitude":35.859111,
     "geom:longitude":127.113999,
@@ -65,10 +65,13 @@
         85673195
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"35012"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154714,
-    "wof:geomhash":"3881035b6c854fe4e7e748e8d96404c3",
+    "wof:geomhash":"415bac33ac0e361e628d642f93a9641e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746469,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886768,
     "wof:name":"Deokjin",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/110/874/647/1/1108746471.geojson
+++ b/data/110/874/647/1/1108746471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009359,
-    "geom:area_square_m":93866935.474177,
+    "geom:area_square_m":93867042.907276,
     "geom:bbox":"127.056817,35.729694,127.222068,35.843353",
     "geom:latitude":35.792515,
     "geom:longitude":127.123081,
@@ -65,10 +65,13 @@
         85673195
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"35011"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154714,
-    "wof:geomhash":"cd5660ac3b1fc440215558566372edbc",
+    "wof:geomhash":"e777a314b57ef064a291f2833f59bc08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746471,
-    "wof:lastmodified":1627522307,
+    "wof:lastmodified":1695886771,
     "wof:name":"Wansan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/110/874/647/3/1108746473.geojson
+++ b/data/110/874/647/3/1108746473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008173,
-    "geom:area_square_m":80940370.497452,
+    "geom:area_square_m":80940166.990061,
     "geom:bbox":"127.539728,36.702684,127.666803,36.860401",
     "geom:latitude":36.787312,
     "geom:longitude":127.605628,
@@ -65,10 +65,13 @@
         85673173
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"33390"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154714,
-    "wof:geomhash":"69004ea58860ab9907cdb6915f29da18",
+    "wof:geomhash":"3266a97ef0c5b51b4195bf10dcb4e69a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746473,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jeungpyeong",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/110/874/647/5/1108746475.geojson
+++ b/data/110/874/647/5/1108746475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011705,
-    "geom:area_square_m":118363775.386072,
+    "geom:area_square_m":118364252.41581,
     "geom:bbox":"128.607086,35.060417,128.84515,35.181246",
     "geom:latitude":35.133481,
     "geom:longitude":128.734002,
@@ -131,11 +131,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"38115",
         "wd:id":"Q50446"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154714,
-    "wof:geomhash":"066866042cc453ae4b183a6190eef01f",
+    "wof:geomhash":"e57df080fb75e7b2c2dc99d47defb552",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -145,7 +147,7 @@
         }
     ],
     "wof:id":1108746475,
-    "wof:lastmodified":1690938305,
+    "wof:lastmodified":1695886624,
     "wof:name":"Jinhae",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/647/9/1108746479.geojson
+++ b/data/110/874/647/9/1108746479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000349,
-    "geom:area_square_m":3526426.598593,
+    "geom:area_square_m":3526385.833166,
     "geom:bbox":"129.024465,35.091378,129.05,35.115348",
     "geom:latitude":35.103556,
     "geom:longitude":129.034367,
@@ -65,10 +65,13 @@
         85673227
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"21010"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154714,
-    "wof:geomhash":"dd980e50252b5d5b17a95b154b146af6",
+    "wof:geomhash":"744fd7ee09f7e53cb46bb470774ab707",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746479,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jung",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/110/874/648/1/1108746481.geojson
+++ b/data/110/874/648/1/1108746481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000743,
-    "geom:area_square_m":7442308.436321,
+    "geom:area_square_m":7442333.577188,
     "geom:bbox":"128.575055,35.855304,128.61563,35.880272",
     "geom:latitude":35.867749,
     "geom:longitude":128.59517,
@@ -65,10 +65,13 @@
         85673213
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"22010"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154715,
-    "wof:geomhash":"055bf4b3fa5bd5eeabe74ae8d163fd01",
+    "wof:geomhash":"24a10cec40ab9cbdd1db58148dd745a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746481,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jung",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/110/874/648/3/1108746483.geojson
+++ b/data/110/874/648/3/1108746483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006076,
-    "geom:area_square_m":60562895.716753,
+    "geom:area_square_m":60563077.143883,
     "geom:bbox":"127.371452,36.207777,127.45556,36.348089",
     "geom:latitude":36.280521,
     "geom:longitude":127.413135,
@@ -65,10 +65,13 @@
         85673207
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"25020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154716,
-    "wof:geomhash":"c99b86a3b12c0722b4c515fc12ed0c8f",
+    "wof:geomhash":"838d11f8c9801a9c0e3eab842306b784",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746483,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jung",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/110/874/648/5/1108746485.geojson
+++ b/data/110/874/648/5/1108746485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009488,
-    "geom:area_square_m":93121000.522791,
+    "geom:area_square_m":93120783.379224,
     "geom:bbox":"126.356163,37.343693,126.643866,37.556999",
     "geom:latitude":37.467377,
     "geom:longitude":126.50193,
@@ -65,10 +65,13 @@
         85673177
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"23010"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154716,
-    "wof:geomhash":"4d801202003e7dc933c16e28aa60164b",
+    "wof:geomhash":"8e77f0d785410d852f1e1f2033fbba63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746485,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jung",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/110/874/648/7/1108746487.geojson
+++ b/data/110/874/648/7/1108746487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003697,
-    "geom:area_square_m":37180739.260543,
+    "geom:area_square_m":37180934.933167,
     "geom:bbox":"129.260299,35.545483,129.356412,35.600134",
     "geom:latitude":35.572123,
     "geom:longitude":129.311578,
@@ -65,10 +65,13 @@
         85673231
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"26010"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154716,
-    "wof:geomhash":"2febc1edaf68abe5bb39614417093da9",
+    "wof:geomhash":"ee330c60a15ede54743bf59a01d9c368",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746487,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jung",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/110/874/648/9/1108746489.geojson
+++ b/data/110/874/648/9/1108746489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001856,
-    "geom:area_square_m":18180698.047983,
+    "geom:area_square_m":18180716.287552,
     "geom:bbox":"127.068992,37.57126,127.120428,37.623598",
     "geom:latitude":37.598375,
     "geom:longitude":127.093396,
@@ -126,11 +126,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"11070",
         "wd:id":"Q50444"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154717,
-    "wof:geomhash":"4e5ff7776e218bf5b7fac2f7231b404a",
+    "wof:geomhash":"7401933f3a2c1614d8cdd8ff7f2b52a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":1108746489,
-    "wof:lastmodified":1690938306,
+    "wof:lastmodified":1695886624,
     "wof:name":"Jungnang",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/110/874/649/1/1108746491.geojson
+++ b/data/110/874/649/1/1108746491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024259,
-    "geom:area_square_m":245313837.806244,
+    "geom:area_square_m":245313940.706545,
     "geom:bbox":"128.349487,35.052055,128.665324,35.221133",
     "geom:latitude":35.134928,
     "geom:longitude":128.488877,
@@ -65,10 +65,13 @@
         85673215
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"38113"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154717,
-    "wof:geomhash":"e1ba7902d532209b36e4e32e4f97e2c8",
+    "wof:geomhash":"085eb70ee4a9eadf2113fca1e3e8ce86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746491,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Masanhappo",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/649/3/1108746493.geojson
+++ b/data/110/874/649/3/1108746493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009231,
-    "geom:area_square_m":93237357.432874,
+    "geom:area_square_m":93237093.457546,
     "geom:bbox":"128.474786,35.173417,128.630805,35.278475",
     "geom:latitude":35.232982,
     "geom:longitude":128.538203,
@@ -65,10 +65,13 @@
         85673215
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"38114"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154717,
-    "wof:geomhash":"872b8b2fed1f2017ebc2f35bf8da16da",
+    "wof:geomhash":"2c3b9fb07385156d40995e42f798533d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746493,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Masanhoewon",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/649/7/1108746497.geojson
+++ b/data/110/874/649/7/1108746497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002349,
-    "geom:area_square_m":23753362.8041,
+    "geom:area_square_m":23753381.138043,
     "geom:bbox":"129.064813,35.092056,129.129578,35.163556",
     "geom:latitude":35.127863,
     "geom:longitude":129.096301,
@@ -71,10 +71,13 @@
         85673227
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"21070"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154717,
-    "wof:geomhash":"052d4529ad6581173f7ff54bf17446c5",
+    "wof:geomhash":"13076191506209429dd164eefbd8bbee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108746497,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Nam",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/110/874/649/9/1108746499.geojson
+++ b/data/110/874/649/9/1108746499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001732,
-    "geom:area_square_m":17358849.668729,
+    "geom:area_square_m":17358951.828007,
     "geom:bbox":"128.557177,35.80915,128.611918,35.86024",
     "geom:latitude":35.836355,
     "geom:longitude":128.587862,
@@ -71,10 +71,13 @@
         85673213
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"22040"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154717,
-    "wof:geomhash":"06d66a006e733b84a921ee4be4e75312",
+    "wof:geomhash":"011ece46b01c7f72fe82ec5bdb07e5fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108746499,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Nam",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/110/874/650/1/1108746501.geojson
+++ b/data/110/874/650/1/1108746501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0392,
-    "geom:area_square_m":392352738.248698,
+    "geom:area_square_m":392352686.027545,
     "geom:bbox":"129.2769,35.839959,129.583771,36.08625",
     "geom:latitude":35.958564,
     "geom:longitude":129.439977,
@@ -105,11 +105,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"37011",
         "wd:id":"Q50366"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154718,
-    "wof:geomhash":"00ea8178757b67537c00ee87d7f1927e",
+    "wof:geomhash":"6caf2f8dba52b860eb57d1c30e250c9d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +121,7 @@
         }
     ],
     "wof:id":1108746501,
-    "wof:lastmodified":1690938305,
+    "wof:lastmodified":1695886770,
     "wof:name":"Nam",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/110/874/650/3/1108746503.geojson
+++ b/data/110/874/650/3/1108746503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002513,
-    "geom:area_square_m":24664147.460882,
+    "geom:area_square_m":24664223.66974,
     "geom:bbox":"126.629724,37.427009,126.701307,37.488347",
     "geom:latitude":37.453314,
     "geom:longitude":126.665782,
@@ -71,10 +71,13 @@
         85673177
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"23030"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154718,
-    "wof:geomhash":"486bf9d4be45c378414d7b9df6acb994",
+    "wof:geomhash":"f8258c1e50f498ccf4cf80ef5dedd7a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108746503,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Nam",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/110/874/650/5/1108746505.geojson
+++ b/data/110/874/650/5/1108746505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007234,
-    "geom:area_square_m":72804873.939915,
+    "geom:area_square_m":72804861.938161,
     "geom:bbox":"129.243779,35.459526,129.387924,35.557813",
     "geom:latitude":35.516689,
     "geom:longitude":129.328533,
@@ -71,10 +71,13 @@
         85673231
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"26020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154718,
-    "wof:geomhash":"a66ac62e952889c2505d93b8d0e2bdc1",
+    "wof:geomhash":"cb14d0e18b802edff5cb6ac61dadb154",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108746505,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Nam",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/110/874/650/7/1108746507.geojson
+++ b/data/110/874/650/7/1108746507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047148,
-    "geom:area_square_m":468271012.258834,
+    "geom:area_square_m":468270917.463047,
     "geom:bbox":"127.132586,36.407688,127.41156,36.734523",
     "geom:latitude":36.561954,
     "geom:longitude":127.259662,
@@ -100,11 +100,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"29010",
         "wd:id":"Q195890"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154718,
-    "wof:geomhash":"95650de3ce34dbce67bd6fb252517ef7",
+    "wof:geomhash":"9b1e93e8448e983091a0dbc3f2bb1b57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +116,7 @@
         }
     ],
     "wof:id":1108746507,
-    "wof:lastmodified":1690938305,
+    "wof:lastmodified":1695886736,
     "wof:name":"Sejong",
     "wof:parent_id":85673243,
     "wof:placetype":"county",

--- a/data/110/874/650/9/1108746509.geojson
+++ b/data/110/874/650/9/1108746509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001344,
-    "geom:area_square_m":13597918.45151,
+    "geom:area_square_m":13598024.836577,
     "geom:bbox":"128.999954,35.047863,129.027787,35.142223",
     "geom:latitude":35.105339,
     "geom:longitude":129.015669,
@@ -83,10 +83,13 @@
         85673227
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"21020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154719,
-    "wof:geomhash":"51203c383f4be317c09344ccf522ba00",
+    "wof:geomhash":"65434382f4786016a6a3a891ceb9984c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1108746509,
-    "wof:lastmodified":1619481385,
+    "wof:lastmodified":1695886624,
     "wof:name":"Seo",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/110/874/651/1/1108746511.geojson
+++ b/data/110/874/651/1/1108746511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001761,
-    "geom:area_square_m":17646850.944295,
+    "geom:area_square_m":17646900.692884,
     "geom:bbox":"128.519705,35.856515,128.58205,35.897937",
     "geom:latitude":35.876461,
     "geom:longitude":128.551392,
@@ -83,10 +83,13 @@
         85673213
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"22030"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154719,
-    "wof:geomhash":"b1a0a8ccc0bd2be832e54a89ead920a9",
+    "wof:geomhash":"6ff8a95691a02cc0640a37c1e2dcffc1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1108746511,
-    "wof:lastmodified":1619481385,
+    "wof:lastmodified":1695886624,
     "wof:name":"Seo",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/110/874/651/5/1108746515.geojson
+++ b/data/110/874/651/5/1108746515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009774,
-    "geom:area_square_m":97425151.906771,
+    "geom:area_square_m":97425187.67054,
     "geom:bbox":"127.28149,36.19,127.405027,36.381342",
     "geom:latitude":36.281092,
     "geom:longitude":127.346488,
@@ -83,10 +83,13 @@
         85673207
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"25030"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154719,
-    "wof:geomhash":"f593348cc0c0906fdd2bb2ea86ec4ac8",
+    "wof:geomhash":"1fc6922fe447f119e6950b933659e907",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1108746515,
-    "wof:lastmodified":1619481385,
+    "wof:lastmodified":1695886624,
     "wof:name":"Seo",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/110/874/651/7/1108746517.geojson
+++ b/data/110/874/651/7/1108746517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009057,
-    "geom:area_square_m":88771707.767869,
+    "geom:area_square_m":88771777.892711,
     "geom:bbox":"126.555359,37.468589,126.724545,37.640983",
     "geom:latitude":37.567598,
     "geom:longitude":126.667394,
@@ -83,10 +83,13 @@
         85673177
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"23080"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154719,
-    "wof:geomhash":"f4bab23342ece66c572d78da151cdb60",
+    "wof:geomhash":"68bcad54d8e7b0130ecf63bfc890c4b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":1108746517,
-    "wof:lastmodified":1619481385,
+    "wof:lastmodified":1695886624,
     "wof:name":"Seo",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/110/874/651/9/1108746519.geojson
+++ b/data/110/874/651/9/1108746519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007351,
-    "geom:area_square_m":72225971.048798,
+    "geom:area_square_m":72226110.778901,
     "geom:bbox":"127.018062,37.325379,127.176976,37.418712",
     "geom:latitude":37.379589,
     "geom:longitude":127.105915,
@@ -68,10 +68,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31023"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154719,
-    "wof:geomhash":"7d58d9b8d72bd3fba80e069b59e243d3",
+    "wof:geomhash":"f88aa32f70318b7dead1b14295a47798",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1108746519,
-    "wof:lastmodified":1627522302,
+    "wof:lastmodified":1695886766,
     "wof:name":"Bundang",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/652/1/1108746521.geojson
+++ b/data/110/874/652/1/1108746521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002797,
-    "geom:area_square_m":27465195.950996,
+    "geom:area_square_m":27465280.001955,
     "geom:bbox":"127.1173,37.405022,127.198713,37.471288",
     "geom:latitude":37.433491,
     "geom:longitude":127.165041,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31022"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154720,
-    "wof:geomhash":"6e2fa22ef2239e5645f84da56c02c269",
+    "wof:geomhash":"9da9776b175e3f7d17ed316e1a88b87a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746521,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Jungwon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/652/3/1108746523.geojson
+++ b/data/110/874/652/3/1108746523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004377,
-    "geom:area_square_m":42975886.006482,
+    "geom:area_square_m":42975782.541649,
     "geom:bbox":"127.042546,37.393923,127.171012,37.47728",
     "geom:latitude":37.435611,
     "geom:longitude":127.105183,
@@ -253,11 +253,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"31021",
         "wd:id":"Q20398"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154720,
-    "wof:geomhash":"0c3d0537c8a7b71e7da8907b67e91e66",
+    "wof:geomhash":"aacdc72c4fabd1858ebbaff36a82ebfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -267,7 +269,7 @@
         }
     ],
     "wof:id":1108746523,
-    "wof:lastmodified":1690938306,
+    "wof:lastmodified":1695886624,
     "wof:name":"Sujeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/652/5/1108746525.geojson
+++ b/data/110/874/652/5/1108746525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00755,
-    "geom:area_square_m":76290075.433825,
+    "geom:area_square_m":76289984.994749,
     "geom:bbox":"128.591202,35.153997,128.753725,35.238028",
     "geom:latitude":35.195163,
     "geom:longitude":128.676066,
@@ -100,11 +100,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"38112",
         "wd:id":"Q50413"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154721,
-    "wof:geomhash":"f81ccc465cefba6c9605427b1c13df4c",
+    "wof:geomhash":"d2fccff163dd40473ec1476e97da2844",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +116,7 @@
         }
     ],
     "wof:id":1108746525,
-    "wof:lastmodified":1690938306,
+    "wof:lastmodified":1695886771,
     "wof:name":"Seongsan",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/652/7/1108746527.geojson
+++ b/data/110/874/652/7/1108746527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004818,
-    "geom:area_square_m":47419565.627502,
+    "geom:area_square_m":47419628.915517,
     "geom:bbox":"126.926376,37.223467,127.044287,37.303871",
     "geom:latitude":37.261354,
     "geom:longitude":126.982139,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31012"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154721,
-    "wof:geomhash":"91db7e9d49f8bbaaa1e0397eebc82571",
+    "wof:geomhash":"1b54192d857432b98c9338c7e61e930e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746527,
-    "wof:lastmodified":1627522304,
+    "wof:lastmodified":1695886769,
     "wof:name":"Gwonseon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/652/9/1108746529.geojson
+++ b/data/110/874/652/9/1108746529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003302,
-    "geom:area_square_m":32473361.661284,
+    "geom:area_square_m":32473302.793739,
     "geom:bbox":"126.96408,37.285773,127.041249,37.354926",
     "geom:latitude":37.314831,
     "geom:longitude":127.005137,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31011"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154721,
-    "wof:geomhash":"95b39913db67ee9a3361a69a5ff0ba8d",
+    "wof:geomhash":"ea513dc0736e293e75838ff8dc4351af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746529,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886770,
     "wof:name":"Jangan",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/653/3/1108746533.geojson
+++ b/data/110/874/653/3/1108746533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001271,
-    "geom:area_square_m":12502293.911141,
+    "geom:area_square_m":12502265.913153,
     "geom:bbox":"126.988427,37.26002,127.045004,37.294666",
     "geom:latitude":37.27761,
     "geom:longitude":127.019633,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31013"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154721,
-    "wof:geomhash":"845ffa889bdceda2297396c4c4e1c3cb",
+    "wof:geomhash":"fe509c4cc5e32d118f881d1fd92577fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746533,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Paldal",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/653/5/1108746535.geojson
+++ b/data/110/874/653/5/1108746535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00285,
-    "geom:area_square_m":28045028.339502,
+    "geom:area_square_m":28045049.936876,
     "geom:bbox":"127.032712,37.231951,127.088392,37.320267",
     "geom:latitude":37.27648,
     "geom:longitude":127.05824,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31014"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154722,
-    "wof:geomhash":"270ae1073aa5e3b16d58ca7a61022372",
+    "wof:geomhash":"062c4fe22c0497da3242fd3c284a9a30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746535,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Yeongtong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/653/7/1108746537.geojson
+++ b/data/110/874/653/7/1108746537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048809,
-    "geom:area_square_m":483831798.829349,
+    "geom:area_square_m":483831819.947253,
     "geom:bbox":"125.537941,36.395363,126.436279,36.979557",
     "geom:latitude":36.709572,
     "geom:longitude":126.272011,
@@ -138,11 +138,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"34380",
         "wd:id":"Q50335"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154722,
-    "wof:geomhash":"4a20b19dba1b91893d73ce7b221fa791",
+    "wof:geomhash":"b753bc82c5819214b04a6280fb175aae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +154,7 @@
         }
     ],
     "wof:id":1108746537,
-    "wof:lastmodified":1690938307,
+    "wof:lastmodified":1695886625,
     "wof:name":"Taean",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/110/874/653/9/1108746539.geojson
+++ b/data/110/874/653/9/1108746539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021664,
-    "geom:area_square_m":218600560.951607,
+    "geom:area_square_m":218600626.660809,
     "geom:bbox":"128.563064,35.211457,128.756821,35.394513",
     "geom:latitude":35.308676,
     "geom:longitude":128.651279,
@@ -100,11 +100,13 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "meso:local_id":"38111",
         "wd:id":"Q50433"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154722,
-    "wof:geomhash":"d518e3699a093fc8c83e27a33b12fe06",
+    "wof:geomhash":"896f48ab639be842e35b9045380365bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +116,7 @@
         }
     ],
     "wof:id":1108746539,
-    "wof:lastmodified":1690938306,
+    "wof:lastmodified":1695886771,
     "wof:name":"Uichang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/110/874/654/1/1108746541.geojson
+++ b/data/110/874/654/1/1108746541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061631,
-    "geom:area_square_m":606182872.531592,
+    "geom:area_square_m":606182843.695597,
     "geom:bbox":"127.400722,37.133619,127.769826,37.440612",
     "geom:latitude":37.303228,
     "geom:longitude":127.617347,
@@ -131,10 +131,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31280"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154722,
-    "wof:geomhash":"a987d0f99e9bece2e13b741844443c7b",
+    "wof:geomhash":"4b30167017023942e461f713d4973545",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":1108746541,
-    "wof:lastmodified":1619481387,
+    "wof:lastmodified":1695886625,
     "wof:name":"Yeoju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/654/3/1108746543.geojson
+++ b/data/110/874/654/3/1108746543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047372,
-    "geom:area_square_m":466548982.01184,
+    "geom:area_square_m":466549145.35193,
     "geom:bbox":"127.108922,37.083966,127.429513,37.3619",
     "geom:latitude":37.204009,
     "geom:longitude":127.25463,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31191"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154723,
-    "wof:geomhash":"e3c02c952f7883201a43719290aca9df",
+    "wof:geomhash":"91941e901b2f52fe38fb73fdd8370920",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746543,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886768,
     "wof:name":"Cheoin",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/654/5/1108746545.geojson
+++ b/data/110/874/654/5/1108746545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008594,
-    "geom:area_square_m":84568811.064846,
+    "geom:area_square_m":84568748.137323,
     "geom:bbox":"127.065207,37.213667,127.17892,37.329646",
     "geom:latitude":37.269183,
     "geom:longitude":127.123451,
@@ -65,10 +65,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31192"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154723,
-    "wof:geomhash":"270c09f284922596fc0e96283c83bceb",
+    "wof:geomhash":"2b56036eca094048ae17bf7bcb6ed380",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":1108746545,
-    "wof:lastmodified":1627522304,
+    "wof:lastmodified":1695886769,
     "wof:name":"Giheung",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/110/874/654/7/1108746547.geojson
+++ b/data/110/874/654/7/1108746547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004144,
-    "geom:area_square_m":40741282.783402,
+    "geom:area_square_m":40741354.389414,
     "geom:bbox":"127.012149,37.292077,127.123663,37.379209",
     "geom:latitude":37.336424,
     "geom:longitude":127.06558,
@@ -71,10 +71,13 @@
         85673191
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"31193"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1479154723,
-    "wof:geomhash":"064dd9814daea0baa46eb3f237899800",
+    "wof:geomhash":"ed3a3e3f2471c1a688778d768748ed64",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108746547,
-    "wof:lastmodified":1627522307,
+    "wof:lastmodified":1695886771,
     "wof:name":"Suji",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/856/322/31/85632231.geojson
+++ b/data/856/322/31/85632231.geojson
@@ -1438,6 +1438,7 @@
         "hasc:id":"KR",
         "icao:code":"HL",
         "ioc:id":"KOR",
+        "iso:code":"KR",
         "itu:id":"KOR",
         "loc:id":"n79126802",
         "m49:code":"410",
@@ -1452,6 +1453,7 @@
         "wk:page":"South Korea",
         "wmo:id":"KO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:country_alpha3":"KOR",
     "wof:geom_alt":[
@@ -1475,7 +1477,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1694639628,
+    "wof:lastmodified":1695881290,
     "wof:name":"South Korea",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/731/73/85673173.geojson
+++ b/data/856/731/73/85673173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.748207,
-    "geom:area_square_m":7413830522.572865,
+    "geom:area_square_m":7413830663.102917,
     "geom:bbox":"127.27857,36.012873,128.650951,37.261023",
     "geom:latitude":36.740008,
     "geom:longitude":127.833299,
@@ -393,16 +393,18 @@
         "gn:id":1845106,
         "gp:id":2345965,
         "hasc:id":"KR.HB",
+        "iso:code":"KR-43",
         "iso:id":"KR-43",
         "qs_pg:id":247163,
         "wd:id":"Q41066",
         "wk:page":"North Chungcheong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c8d507992def17708d06b3cb2fa39b4",
+    "wof:geomhash":"03aa7e831811647ad03870ecd0b90ee8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -417,7 +419,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938285,
+    "wof:lastmodified":1695884672,
     "wof:name":"North Chungcheong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/77/85673177.geojson
+++ b/data/856/731/77/85673177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091823,
-    "geom:area_square_m":899988326.514331,
+    "geom:area_square_m":899989129.058767,
     "geom:bbox":"125.746223,36.920361,126.790115,37.831151",
     "geom:latitude":37.565219,
     "geom:longitude":126.480445,
@@ -516,16 +516,18 @@
         "gn:id":1843561,
         "gp:id":20069922,
         "hasc:id":"KR.IN",
+        "iso:code":"KR-28",
         "iso:id":"KR-28",
         "qs_pg:id":1076914,
         "wd:id":"Q20934",
         "wk:page":"Incheon"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d400725f29b74d5ade2bb14acbd58b1",
+    "wof:geomhash":"ea8ec5a070538045fb09f4051853c443",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -540,7 +542,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938287,
+    "wof:lastmodified":1695884672,
     "wof:name":"Incheon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/81/85673181.geojson
+++ b/data/856/731/81/85673181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.721299,
-    "geom:area_square_m":16833761745.975868,
+    "geom:area_square_m":16833761507.927029,
     "geom:bbox":"127.108386,37.030054,129.365769,38.618412",
     "geom:latitude":37.728372,
     "geom:longitude":128.299745,
@@ -375,17 +375,19 @@
         "gn:id":1843125,
         "gp:id":2345966,
         "hasc:id":"KR.KW",
+        "iso:code":"KR-42",
         "iso:id":"KR-42",
         "loc:id":"n85058039",
         "qs_pg:id":1060818,
         "wd:id":"Q41071",
         "wk:page":"Gangwon Province (South Korea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8df4cef062331cd46644ac7a8f2dabe4",
+    "wof:geomhash":"7824e64c987129142a26420fbbce7c01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938286,
+    "wof:lastmodified":1695884673,
     "wof:name":"Gangwon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/85/85673185.geojson
+++ b/data/856/731/85/85673185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06134,
-    "geom:area_square_m":601317280.680825,
+    "geom:area_square_m":601317350.820797,
     "geom:bbox":"126.769815,37.42764,127.186828,37.703621",
     "geom:latitude":37.552538,
     "geom:longitude":126.996127,
@@ -790,12 +790,14 @@
         "gn:id":1835847,
         "gp:id":20069923,
         "hasc:id":"KR.SO",
+        "iso:code":"KR-11",
         "iso:id":"KR-11",
         "loc:id":"n79066627",
         "qs_pg:id":892916,
         "wd:id":"Q8684",
         "wk:page":"Seoul"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         102026327
     ],
@@ -803,7 +805,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa32acd020be6f729e4e74bed20ca7e2",
+    "wof:geomhash":"2ed3ec0d43e76aec0625065d39f4b6db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -818,7 +820,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938287,
+    "wof:lastmodified":1695884673,
     "wof:name":"Seoul",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/91/85673191.geojson
+++ b/data/856/731/91/85673191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.027303,
-    "geom:area_square_m":10072607459.796656,
+    "geom:area_square_m":10072607882.525789,
     "geom:bbox":"126.379524,36.893584,127.84976,38.295181",
     "geom:latitude":37.537258,
     "geom:longitude":127.188051,
@@ -408,17 +408,19 @@
         "gn:id":1841610,
         "gp:id":2345969,
         "hasc:id":"KR.KG",
+        "iso:code":"KR-41",
         "iso:id":"KR-41",
         "loc:id":"n81072034",
         "qs_pg:id":1079205,
         "wd:id":"Q20937",
         "wk:page":"Gyeonggi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37d09e13226f9b63b3bcded9a7438434",
+    "wof:geomhash":"48a3fe9e2b3ebd5a1f5105cce9f6b103",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -433,7 +435,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938286,
+    "wof:lastmodified":1695885134,
     "wof:name":"Gyeonggi",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/95/85673195.geojson
+++ b/data/856/731/95/85673195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.789003,
-    "geom:area_square_m":7921321280.532456,
+    "geom:area_square_m":7921320964.959125,
     "geom:bbox":"125.955391,35.296734,127.912258,36.259556",
     "geom:latitude":35.71462,
     "geom:longitude":127.151571,
@@ -367,16 +367,18 @@
         "gn:id":1845789,
         "gp:id":2345964,
         "hasc:id":"KR.CB",
+        "iso:code":"KR-45",
         "iso:id":"KR-45",
         "qs_pg:id":1135123,
         "wd:id":"Q41157",
         "wk:page":"North Jeolla Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b8b12d9bbe68fecfb8879e603a77b69",
+    "wof:geomhash":"f761b0d49fe841481cba8afe96609b9a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -391,7 +393,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938285,
+    "wof:lastmodified":1695884673,
     "wof:name":"North Jeolla",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/731/99/85673199.geojson
+++ b/data/856/731/99/85673199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049693,
-    "geom:area_square_m":502378899.184985,
+    "geom:area_square_m":502379273.886496,
     "geom:bbox":"126.651539,35.050889,127.021746,35.259855",
     "geom:latitude":35.1559,
     "geom:longitude":126.837662,
@@ -475,15 +475,17 @@
         "gn:id":1841808,
         "gp:id":2345974,
         "hasc:id":"KR.CN",
+        "iso:code":"KR-46",
         "iso:id":"KR-46",
         "qs_pg:id":191374,
         "wd:id":"Q41283"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f546252f9d6ceb2b76b35e96b7b71f9f",
+    "wof:geomhash":"7a6713a503cd7720f877f18b2f5c8ff7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -498,7 +500,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938287,
+    "wof:lastmodified":1695884673,
     "wof:name":"Gwangju",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/03/85673203.geojson
+++ b/data/856/732/03/85673203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.796983,
-    "geom:area_square_m":7919761479.552272,
+    "geom:area_square_m":7919761178.009052,
     "geom:bbox":"125.537941,35.979611,127.63861,37.072029",
     "geom:latitude":36.519951,
     "geom:longitude":126.8622,
@@ -387,16 +387,18 @@
         "gn:id":1845105,
         "gp:id":2345973,
         "hasc:id":"KR.HN",
+        "iso:code":"KR-44",
         "iso:id":"KR-44",
         "qs_pg:id":9199,
         "wd:id":"Q41070",
         "wk:page":"South Chungcheong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d08bf48dad9ee4fa691f9c26816d2b45",
+    "wof:geomhash":"f8da19910bfadabffccdb9a4425bad42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -411,7 +413,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938290,
+    "wof:lastmodified":1695884673,
     "wof:name":"South Chungcheong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/07/85673207.geojson
+++ b/data/856/732/07/85673207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05417,
-    "geom:area_square_m":539550075.742368,
+    "geom:area_square_m":539550086.401601,
     "geom:bbox":"127.249035,36.19,127.555093,36.502324",
     "geom:latitude":36.340663,
     "geom:longitude":127.394915,
@@ -476,16 +476,18 @@
         "gn:id":1835224,
         "gp:id":2345975,
         "hasc:id":"KR.TJ",
+        "iso:code":"KR-30",
         "iso:id":"KR-30",
         "qs_pg:id":1135127,
         "wd:id":"Q20921",
         "wk:page":"Daejeon"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b45474098e9907c2ecf99a1d7fbdd13d",
+    "wof:geomhash":"493cbc5c79d2ebb54fac3cdc05e424ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -500,7 +502,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938292,
+    "wof:lastmodified":1695884675,
     "wof:name":"Daejeon",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/13/85673213.geojson
+++ b/data/856/732/13/85673213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087066,
-    "geom:area_square_m":872837530.60713,
+    "geom:area_square_m":872837489.820438,
     "geom:bbox":"128.350812,35.614253,128.768854,36.016681",
     "geom:latitude":35.831624,
     "geom:longitude":128.567406,
@@ -482,16 +482,18 @@
         "gn:id":1835327,
         "gp:id":2345971,
         "hasc:id":"KR.TG",
+        "iso:code":"KR-27",
         "iso:id":"KR-27",
         "qs_pg:id":891328,
         "wd:id":"Q20927",
         "wk:page":"Daegu"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"698c006861e38dc8767fce1364af0192",
+    "wof:geomhash":"97b37d60b5a6c2bc2ec82f9859545cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -506,7 +508,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938294,
+    "wof:lastmodified":1695884675,
     "wof:name":"Daegu",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/15/85673215.geojson
+++ b/data/856/732/15/85673215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.054614,
-    "geom:area_square_m":10640118006.177977,
+    "geom:area_square_m":10640118634.553946,
     "geom:bbox":"127.576244,34.497082,129.220001,35.910758",
     "geom:latitude":35.319889,
     "geom:longitude":128.263532,
@@ -397,16 +397,18 @@
         "gn:id":1902028,
         "gp:id":2345967,
         "hasc:id":"KR.KN",
+        "iso:code":"KR-48",
         "iso:id":"KR-48",
         "qs_pg:id":905734,
         "wd:id":"Q41151",
         "wk:page":"South Gyeongsang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"315705fc9d2dfcab16fb62c1c59a0e18",
+    "wof:geomhash":"6388539424d45cb609ec980abc3aa0a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -421,7 +423,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938293,
+    "wof:lastmodified":1695884675,
     "wof:name":"South Gyeongsang",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/19/85673219.geojson
+++ b/data/856/732/19/85673219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.186213,
-    "geom:area_square_m":12033374698.791426,
+    "geom:area_square_m":12033375772.094921,
     "geom:bbox":"125.074585,33.918694,127.906197,35.489536",
     "geom:latitude":34.874404,
     "geom:longitude":126.904504,
@@ -366,16 +366,18 @@
         "gn:id":1845788,
         "gp:id":2345972,
         "hasc:id":"KR.KJ",
+        "iso:code":"KR-29",
         "iso:id":"KR-29",
         "qs_pg:id":1250616,
         "wd:id":"Q41161",
         "wk:page":"South Jeolla Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4b20ed08fd3bf0e6f3cfcd41bbc7152",
+    "wof:geomhash":"43c37887030903e7a611a78f527437fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -390,7 +392,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938291,
+    "wof:lastmodified":1695884673,
     "wof:name":"South Jeolla",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/27/85673227.geojson
+++ b/data/856/732/27/85673227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073178,
-    "geom:area_square_m":739352717.344001,
+    "geom:area_square_m":739352772.254397,
     "geom:bbox":"128.773024,34.882915,129.306941,35.389982",
     "geom:latitude":35.205121,
     "geom:longitude":129.065403,
@@ -547,17 +547,19 @@
         "gn:id":1838519,
         "gp:id":2345968,
         "hasc:id":"KR.PU",
+        "iso:code":"KR-26",
         "iso:id":"KR-26",
         "loc:id":"n80013546",
         "qs_pg:id":1168672,
         "wd:id":"Q16520",
         "wk:page":"Busan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"990494dcd6e8cb2e8ccbe5cf7f0f9ec1",
+    "wof:geomhash":"dfc918b65f6ba601b27496c1b0773038",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -572,7 +574,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938291,
+    "wof:lastmodified":1695884674,
     "wof:name":"Busan",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/31/85673231.geojson
+++ b/data/856/732/31/85673231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10541,
-    "geom:area_square_m":1060397239.087584,
+    "geom:area_square_m":1060397354.73334,
     "geom:bbox":"128.972001,35.329582,129.465424,35.726015",
     "geom:latitude":35.555257,
     "geom:longitude":129.238079,
@@ -453,16 +453,18 @@
         "gn:id":1833742,
         "gp:id":23701285,
         "hasc:id":"KR.UL",
+        "iso:code":"KR-31",
         "iso:id":"KR-31",
         "qs_pg:id":59176,
         "wd:id":"Q41278",
         "wk:page":"Ulsan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86ba3efb48176178ca151d23ccaef503",
+    "wof:geomhash":"899fb08f1af4c0c94f906a46202433d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -477,7 +479,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938293,
+    "wof:lastmodified":1695884675,
     "wof:name":"Ulsan",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/33/85673233.geojson
+++ b/data/856/732/33/85673233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.911293,
-    "geom:area_square_m":19034384640.985695,
+    "geom:area_square_m":19034384173.527172,
     "geom:bbox":"127.795649,35.5661,130.950394,37.546223",
     "geom:latitude":36.349489,
     "geom:longitude":128.750454,
@@ -394,16 +394,18 @@
         "gn:id":1841597,
         "gp:id":2345970,
         "hasc:id":"KR.KB",
+        "iso:code":"KR-47",
         "iso:id":"KR-47",
         "qs_pg:id":1207487,
         "wd:id":"Q41154",
         "wk:page":"North Gyeongsang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"529b0232fdd7793a373f6c4ade349f59",
+    "wof:geomhash":"7888298c3e25012de89d5ca9921da19b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -418,7 +420,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938290,
+    "wof:lastmodified":1695884675,
     "wof:name":"North Gyeongsang",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/37/85673237.geojson
+++ b/data/856/732/37/85673237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180929,
-    "geom:area_square_m":1867979094.942125,
+    "geom:area_square_m":1867979026.386331,
     "geom:bbox":"126.144554,33.112862,126.969612,34.014584",
     "geom:latitude":33.388867,
     "geom:longitude":126.55316,
@@ -432,16 +432,18 @@
         "gn:id":1846265,
         "gp:id":2345963,
         "hasc:id":"KR.CJ",
+        "iso:code":"KR-49",
         "iso:id":"KR-49",
         "qs_pg:id":1075585,
         "wd:id":"Q41164",
         "wk:page":"Jeju Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf03961da597929c3251c6f791ca1fa2",
+    "wof:geomhash":"4996bc85c71e0cb73b3de41d6d76a28c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -456,7 +458,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938293,
+    "wof:lastmodified":1695884852,
     "wof:name":"Jeju",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/856/732/43/85673243.geojson
+++ b/data/856/732/43/85673243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047148,
-    "geom:area_square_m":468271012.258834,
+    "geom:area_square_m":468270917.463047,
     "geom:bbox":"127.132586,36.407688,127.41156,36.734523",
     "geom:latitude":36.561954,
     "geom:longitude":127.259662,
@@ -181,14 +181,16 @@
         "gn:id":8394437,
         "gp:id":-2345973,
         "hasc:id":"KR.SJ",
+        "iso:code":"KR-50",
         "iso:id":"KR-50",
         "unlc:id":"KR-50"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"95650de3ce34dbce67bd6fb252517ef7",
+    "wof:geomhash":"9b1e93e8448e983091a0dbc3f2bb1b57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +205,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1636497459,
+    "wof:lastmodified":1695884852,
     "wof:name":"Sejong",
     "wof:parent_id":85632231,
     "wof:placetype":"region",

--- a/data/890/472/085/890472085.geojson
+++ b/data/890/472/085/890472085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001123,
-    "geom:area_square_m":11345379.068564,
+    "geom:area_square_m":11345434.406278,
     "geom:bbox":"129.056836,35.161438,129.112601,35.201165",
     "geom:latitude":35.184258,
     "geom:longitude":129.082981,
@@ -145,16 +145,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462807,
+        "meso:local_id":"21130",
         "qs_pg:id":209105,
         "wd:id":"Q50422",
         "wk:page":"Yeonje District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"777666ccc92d8360c55bb2fad3a0864d",
+    "wof:geomhash":"ba7095f41132bd1cff83cca957abfed0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +166,7 @@
         }
     ],
     "wof:id":890472085,
-    "wof:lastmodified":1690938330,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yeonje",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/091/890472091.geojson
+++ b/data/890/472/091/890472091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005306,
-    "geom:area_square_m":53615698.339685,
+    "geom:area_square_m":53615599.173227,
     "geom:bbox":"129.109705,35.152889,129.211667,35.250548",
     "geom:latitude":35.196088,
     "geom:longitude":129.156565,
@@ -148,16 +148,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462808,
+        "meso:local_id":"21090",
         "qs_pg:id":209113,
         "wd:id":"Q50449",
         "wk:page":"Haeundae District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1afe5cd4147346fc001ebf02776ff51c",
+    "wof:geomhash":"fceed102d505fc4812df3f1498edbcba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
         }
     ],
     "wof:id":890472091,
-    "wof:lastmodified":1690938330,
+    "wof:lastmodified":1695886629,
     "wof:name":"Haeundae",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/093/890472093.geojson
+++ b/data/890/472/093/890472093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017012,
-    "geom:area_square_m":172015977.854111,
+    "geom:area_square_m":172016308.358864,
     "geom:bbox":"128.773024,34.987888,129.005555,35.232746",
     "geom:latitude":35.140784,
     "geom:longitude":128.895878,
@@ -112,16 +112,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462812,
+        "meso:local_id":"21120",
         "qs_pg:id":209114,
         "wd:id":"Q439427",
         "wk:page":"Gangseo-gu"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4e6ed832534370c0d0e6795a84703e1",
+    "wof:geomhash":"710bd3eff275a8007d9e3f3077d6e321",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +133,7 @@
         }
     ],
     "wof:id":890472093,
-    "wof:lastmodified":1690938338,
+    "wof:lastmodified":1695886631,
     "wof:name":"Gangseo",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/095/890472095.geojson
+++ b/data/890/472/095/890472095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005008,
-    "geom:area_square_m":50648998.832313,
+    "geom:area_square_m":50648998.855534,
     "geom:bbox":"126.908074,35.070889,127.001736,35.167231",
     "geom:latitude":35.117879,
     "geom:longitude":126.950387,
@@ -153,14 +153,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462137,
+        "meso:local_id":"24010",
         "qs_pg:id":209115
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22e8e0cd121f42538f0cd398bb026ab7",
+    "wof:geomhash":"ff6b62c076e849f5d8db4c889f7d0995",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890472095,
-    "wof:lastmodified":1636497473,
+    "wof:lastmodified":1695886737,
     "wof:name":"Dong",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/472/097/890472097.geojson
+++ b/data/890/472/097/890472097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006324,
-    "geom:area_square_m":63855434.967455,
+    "geom:area_square_m":63855474.713158,
     "geom:bbox":"129.04135,35.208731,129.145734,35.307098",
     "geom:latitude":35.26004,
     "geom:longitude":129.093682,
@@ -133,16 +133,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462814,
+        "meso:local_id":"21110",
         "qs_pg:id":209116,
         "wd:id":"Q50358",
         "wk:page":"Geumjeong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f01acf62634387bdf45ae105ee87e51",
+    "wof:geomhash":"2cb9f6ccb061cf2d803fc4713addc67d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +154,7 @@
         }
     ],
     "wof:id":890472097,
-    "wof:lastmodified":1690938332,
+    "wof:lastmodified":1695886768,
     "wof:name":"Geumjeong",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/099/890472099.geojson
+++ b/data/890/472/099/890472099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021274,
-    "geom:area_square_m":214698532.828462,
+    "geom:area_square_m":214698569.22147,
     "geom:bbox":"129.112032,35.179554,129.306941,35.389982",
     "geom:latitude":35.298557,
     "geom:longitude":129.203538,
@@ -145,16 +145,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462815,
+        "meso:local_id":"21310",
         "qs_pg:id":209117,
         "wd:id":"Q50217",
         "wk:page":"Gijang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053881,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35b58c4af8bf932108097cfcc496b7b8",
+    "wof:geomhash":"8d1727c6a09fcac32f9915c98c4da7a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +166,7 @@
         }
     ],
     "wof:id":890472099,
-    "wof:lastmodified":1690938332,
+    "wof:lastmodified":1695886768,
     "wof:name":"Gijang",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/472/181/890472181.geojson
+++ b/data/890/472/181/890472181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042804,
-    "geom:area_square_m":425097475.820481,
+    "geom:area_square_m":425097366.772761,
     "geom:bbox":"126.426224,36.457771,126.773264,36.672781",
     "geom:latitude":36.567751,
     "geom:longitude":126.631764,
@@ -172,16 +172,18 @@
     "wof:concordances":{
         "gn:id":8393539,
         "gp:id":28289203,
+        "meso:local_id":"34360",
         "qs_pg:id":1246254,
         "wd:id":"Q50343",
         "wk:page":"Hongseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d2c476f3c0a4de2ee9d23546a5632363",
+    "wof:geomhash":"57904613c94cd6eb3c8b408d21122c33",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +193,7 @@
         }
     ],
     "wof:id":890472181,
-    "wof:lastmodified":1690938335,
+    "wof:lastmodified":1695886630,
     "wof:name":"Hongseong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/185/890472185.geojson
+++ b/data/890/472/185/890472185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005848,
-    "geom:area_square_m":59168309.984318,
+    "geom:area_square_m":59168204.785889,
     "geom:bbox":"126.762298,35.050889,126.928996,35.155595",
     "geom:latitude":35.093733,
     "geom:longitude":126.857263,
@@ -271,16 +271,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462135,
+        "meso:local_id":"24030",
         "qs_pg:id":1246292,
         "wd:id":"Q400172",
         "wk:page":"Nam-gu"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a3ecdce6d90fb7841fe13e5b7bed221",
+    "wof:geomhash":"b1d37109f9aa148c7b67c18cf1b4690c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -290,7 +292,7 @@
         }
     ],
     "wof:id":890472185,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Nam",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/472/187/890472187.geojson
+++ b/data/890/472/187/890472187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003008,
-    "geom:area_square_m":29517178.978234,
+    "geom:area_square_m":29517069.694158,
     "geom:bbox":"126.907433,37.437465,126.993032,37.495702",
     "geom:latitude":37.468723,
     "geom:longitude":126.946833,
@@ -152,16 +152,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1841893,
+        "meso:local_id":"11210",
         "qs_pg:id":275267,
         "wd:id":"Q50353",
         "wk:page":"Gwanak District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"18173fcede23998825516bd1a7d9ef81",
+    "wof:geomhash":"0c3f8eed9d29e9156d871729af6254f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +173,7 @@
         }
     ],
     "wof:id":890472187,
-    "wof:lastmodified":1690938333,
+    "wof:lastmodified":1695886630,
     "wof:name":"Gwanak",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/189/890472189.geojson
+++ b/data/890/472/189/890472189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043836,
-    "geom:area_square_m":447097617.806529,
+    "geom:area_square_m":447097713.471735,
     "geom:bbox":"125.801193,34.131195,126.384613,34.589584",
     "geom:latitude":34.428185,
     "geom:longitude":126.202537,
@@ -136,16 +136,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1846089,
+        "meso:local_id":"36470",
         "qs_pg:id":276647,
         "wd:id":"Q50325",
         "wk:page":"Jindo County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053885,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6df4c168234fcc61bb411bca72dabc49",
+    "wof:geomhash":"6c5b74d908f9c651a955e73d4fd90351",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +157,7 @@
         }
     ],
     "wof:id":890472189,
-    "wof:lastmodified":1690938334,
+    "wof:lastmodified":1695886631,
     "wof:name":"Jindo",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/247/890472247.geojson
+++ b/data/890/472/247/890472247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042007,
-    "geom:area_square_m":425334525.492871,
+    "geom:area_square_m":425334500.383843,
     "geom:bbox":"127.52667,34.885361,127.797058,35.183372",
     "geom:latitude":35.030124,
     "geom:longitude":127.651533,
@@ -240,16 +240,18 @@
     "wof:concordances":{
         "gn:id":1841773,
         "gp:id":28289193,
+        "meso:local_id":"36060",
         "qs_pg:id":351263,
         "wd:id":"Q42067",
         "wk:page":"Gwangyang"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"65784e1e1b8a34aa61fc0a4e1c564bfa",
+    "wof:geomhash":"0d173358d1624d464b3eb258939330cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -259,7 +261,7 @@
         }
     ],
     "wof:id":890472247,
-    "wof:lastmodified":1690938337,
+    "wof:lastmodified":1695886632,
     "wof:name":"Gwangyang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/251/890472251.geojson
+++ b/data/890/472/251/890472251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061431,
-    "geom:area_square_m":612909852.940045,
+    "geom:area_square_m":612909913.153623,
     "geom:bbox":"128.133416,36.061799,128.562355,36.366186",
     "geom:latitude":36.208454,
     "geom:longitude":128.357248,
@@ -108,14 +108,16 @@
     "wof:concordances":{
         "gn:id":1842218,
         "gp:id":28289180,
+        "meso:local_id":"37050",
         "qs_pg:id":355254
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9788a5de6a8ef8255161c7ebd97d1e18",
+    "wof:geomhash":"4cffb9e938589108a14adfd13be548fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +127,7 @@
         }
     ],
     "wof:id":890472251,
-    "wof:lastmodified":1619481394,
+    "wof:lastmodified":1695886631,
     "wof:name":"Gumi",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/253/890472253.geojson
+++ b/data/890/472/253/890472253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043279,
-    "geom:area_square_m":425119027.981054,
+    "geom:area_square_m":425118990.317436,
     "geom:bbox":"127.132179,37.267411,127.45,37.537945",
     "geom:latitude":37.40335,
     "geom:longitude":127.302343,
@@ -294,14 +294,16 @@
     "wof:concordances":{
         "gn:id":8393801,
         "gp:id":28289190,
+        "meso:local_id":"31250",
         "qs_pg:id":355255
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"afc81c2113dca46e78ec483078941869",
+    "wof:geomhash":"c3f75dbbea33a0c20a14d332cb5a333e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -311,7 +313,7 @@
         }
     ],
     "wof:id":890472253,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Gwangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/255/890472255.geojson
+++ b/data/890/472/255/890472255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099432,
-    "geom:area_square_m":981707184.92011,
+    "geom:area_square_m":981707075.732911,
     "geom:bbox":"127.652068,36.799874,128.124598,37.211769",
     "geom:latitude":37.01613,
     "geom:longitude":127.897344,
@@ -173,14 +173,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289138,
+        "meso:local_id":"33020",
         "qs_pg:id":407610
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ccb958b8bc8e81ea3d31c2995dfb7797",
+    "wof:geomhash":"94811fa5aac877c677e771bf557ba248",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -190,7 +192,7 @@
         }
     ],
     "wof:id":890472255,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Chungju",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/257/890472257.geojson
+++ b/data/890/472/257/890472257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078889,
-    "geom:area_square_m":790886681.159442,
+    "geom:area_square_m":790887037.615542,
     "geom:bbox":"127.264946,35.616841,127.625712,36.029923",
     "geom:latitude":35.829174,
     "geom:longitude":127.430677,
@@ -141,16 +141,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289220,
+        "meso:local_id":"35320",
         "qs_pg:id":237316,
         "wd:id":"Q50326",
         "wk:page":"Jinan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c9b8edf5d1987c08250c643011e5814",
+    "wof:geomhash":"fa8fd29111ecfa2ccc9df220fdafbe48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890472257,
-    "wof:lastmodified":1690938330,
+    "wof:lastmodified":1695886629,
     "wof:name":"Jinan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/472/259/890472259.geojson
+++ b/data/890/472/259/890472259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043196,
-    "geom:area_square_m":441271947.2057,
+    "geom:area_square_m":441271862.021219,
     "geom:bbox":"126.330883,33.918694,127.18042,34.461224",
     "geom:latitude":34.293498,
     "geom:longitude":126.779145,
@@ -139,16 +139,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1833493,
+        "meso:local_id":"36460",
         "qs_pg:id":356074,
         "wd:id":"Q50311",
         "wk:page":"Wando County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1d3118d2d8de2cda2364cf67adfd50c",
+    "wof:geomhash":"aa487d73c3e06df745dc071395903cf9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +160,7 @@
         }
     ],
     "wof:id":890472259,
-    "wof:lastmodified":1690938331,
+    "wof:lastmodified":1695886629,
     "wof:name":"Wando",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/273/890472273.geojson
+++ b/data/890/472/273/890472273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004755,
-    "geom:area_square_m":48080703.112957,
+    "geom:area_square_m":48080660.554067,
     "geom:bbox":"126.803717,35.091041,126.89858,35.181061",
     "geom:latitude":35.136838,
     "geom:longitude":126.852254,
@@ -272,16 +272,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462134,
+        "meso:local_id":"24020",
         "qs_pg:id":381740,
         "wd:id":"Q418825",
         "wk:page":"Seo-gu"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053888,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66a3f7814238b616a92d846144a9fe1e",
+    "wof:geomhash":"4ef2552a70483708a1f861f23f03ee07",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -297,7 +299,7 @@
         }
     ],
     "wof:id":890472273,
-    "wof:lastmodified":1619481393,
+    "wof:lastmodified":1695886630,
     "wof:name":"Seo",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/890/472/293/890472293.geojson
+++ b/data/890/472/293/890472293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001756,
-    "geom:area_square_m":17216141.208436,
+    "geom:area_square_m":17216320.177389,
     "geom:bbox":"127.058447,37.525146,127.117121,37.573081",
     "geom:latitude":37.547811,
     "geom:longitude":127.088143,
@@ -149,16 +149,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349529,
+        "meso:local_id":"11050",
         "qs_pg:id":1155771,
         "wd:id":"Q50355",
         "wk:page":"Gwangjin District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053889,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8fbda1679cfcc3c5ce9cabb8fedc0fe7",
+    "wof:geomhash":"62dd110a52112d20a1a5d6e2a48ca61a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +170,7 @@
         }
     ],
     "wof:id":890472293,
-    "wof:lastmodified":1690938332,
+    "wof:lastmodified":1695886631,
     "wof:name":"Gwangjin",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/295/890472295.geojson
+++ b/data/890/472/295/890472295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003679,
-    "geom:area_square_m":36021295.331695,
+    "geom:area_square_m":36021290.542593,
     "geom:bbox":"127.043492,37.612242,127.113825,37.702852",
     "geom:latitude":37.652437,
     "geom:longitude":127.076777,
@@ -146,16 +146,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349531,
+        "meso:local_id":"11110",
         "qs_pg:id":1155772,
         "wd:id":"Q50368",
         "wk:page":"Nowon District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053889,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8fc575e2fce3545d4cd1dad2cd70cf38",
+    "wof:geomhash":"5e7d49aa6004117f4857a90e11cfb985",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":890472295,
-    "wof:lastmodified":1690938331,
+    "wof:lastmodified":1695886630,
     "wof:name":"Nowon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/297/890472297.geojson
+++ b/data/890/472/297/890472297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002299,
-    "geom:area_square_m":22519162.71187,
+    "geom:area_square_m":22519127.882652,
     "geom:bbox":"126.980276,37.574779,127.069441,37.635315",
     "geom:latitude":37.606013,
     "geom:longitude":127.019099,
@@ -146,16 +146,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349532,
+        "meso:local_id":"11080",
         "qs_pg:id":1155773,
         "wd:id":"Q50412",
         "wk:page":"Seongbuk District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053889,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09cc5ef291208546fdefa3ec2a504fb9",
+    "wof:geomhash":"7bbbc020597750fb4f8a2eecef969a36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":890472297,
-    "wof:lastmodified":1690938338,
+    "wof:lastmodified":1695886632,
     "wof:name":"Seongbuk",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/299/890472299.geojson
+++ b/data/890/472/299/890472299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001621,
-    "geom:area_square_m":15895926.037432,
+    "geom:area_square_m":15895954.991858,
     "geom:bbox":"126.822697,37.505599,126.892754,37.550717",
     "geom:latitude":37.526132,
     "geom:longitude":126.858771,
@@ -148,16 +148,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349533,
+        "meso:local_id":"11150",
         "qs_pg:id":1155774,
         "wd:id":"Q50420",
         "wk:page":"Yangcheon District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053889,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7fb98b966a7681dbb56c699a7aa697d3",
+    "wof:geomhash":"f983f8f59f148fb717f03180ccb69656",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
         }
     ],
     "wof:id":890472299,
-    "wof:lastmodified":1690938338,
+    "wof:lastmodified":1695886632,
     "wof:name":"Yangcheon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/301/890472301.geojson
+++ b/data/890/472/301/890472301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001267,
-    "geom:area_square_m":12440574.889267,
+    "geom:area_square_m":12440647.58492,
     "geom:bbox":"126.877587,37.432879,126.931043,37.484224",
     "geom:latitude":37.46038,
     "geom:longitude":126.904123,
@@ -152,16 +152,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349534,
+        "meso:local_id":"11180",
         "qs_pg:id":1155775,
         "wd:id":"Q50359",
         "wk:page":"Geumcheon District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053889,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4ab3e6f811be452eb4ea8c63ef122b59",
+    "wof:geomhash":"08fdb8606351cae23ee5d8a53a733bb2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +173,7 @@
         }
     ],
     "wof:id":890472301,
-    "wof:lastmodified":1690938327,
+    "wof:lastmodified":1695886630,
     "wof:name":"Geumcheon",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/323/890472323.geojson
+++ b/data/890/472/323/890472323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058524,
-    "geom:area_square_m":592855896.156561,
+    "geom:area_square_m":592855892.039725,
     "geom:bbox":"126.517059,34.867484,126.900038,35.115877",
     "geom:latitude":34.990135,
     "geom:longitude":126.724914,
@@ -226,16 +226,18 @@
     "wof:concordances":{
         "gn:id":1840535,
         "gp:id":28289249,
+        "meso:local_id":"36040",
         "qs_pg:id":356114,
         "wd:id":"Q42083",
         "wk:page":"Naju"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053890,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f40b8ca4e22b9b872113ff3538afa01d",
+    "wof:geomhash":"837ecab1979aa2f5d4458465ad27a8da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -245,7 +247,7 @@
         }
     ],
     "wof:id":890472323,
-    "wof:lastmodified":1690938334,
+    "wof:lastmodified":1695886631,
     "wof:name":"Naju",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/333/890472333.geojson
+++ b/data/890/472/333/890472333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058484,
-    "geom:area_square_m":581392644.914112,
+    "geom:area_square_m":581392943.084752,
     "geom:bbox":"127.513663,36.368092,127.907228,36.614165",
     "geom:latitude":36.490992,
     "geom:longitude":127.730653,
@@ -163,16 +163,18 @@
     "wof:concordances":{
         "gn:id":1838730,
         "gp:id":28289112,
+        "meso:local_id":"33320",
         "qs_pg:id":1202126,
         "wd:id":"Q50244",
         "wk:page":"Boeun County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053895,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"83f8743f2dc501a88c4ab349210b4524",
+    "wof:geomhash":"c7c83b1ee2bc7519a6467c0325e52110",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +184,7 @@
         }
     ],
     "wof:id":890472333,
-    "wof:lastmodified":1690938336,
+    "wof:lastmodified":1695886766,
     "wof:name":"Boeun",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/345/890472345.geojson
+++ b/data/890/472/345/890472345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126018,
-    "geom:area_square_m":1253731570.884065,
+    "geom:area_square_m":1253731697.09133,
     "geom:bbox":"127.795649,36.238345,128.339866,36.654306",
     "geom:latitude":36.430097,
     "geom:longitude":128.068407,
@@ -154,14 +154,16 @@
     "wof:concordances":{
         "gn:id":1837705,
         "gp:id":28289274,
+        "meso:local_id":"37080",
         "qs_pg:id":1203256
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053896,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f974a8acd1751ec5498a28af3932a72b",
+    "wof:geomhash":"234d16dcd5d8dadf504748a2242a6b23",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +173,7 @@
         }
     ],
     "wof:id":890472345,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Sangju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/363/890472363.geojson
+++ b/data/890/472/363/890472363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039055,
-    "geom:area_square_m":395768246.251924,
+    "geom:area_square_m":395768341.036236,
     "geom:bbox":"126.239556,34.777889,126.542053,35.167084",
     "geom:latitude":34.96205,
     "geom:longitude":126.422721,
@@ -150,16 +150,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289246,
+        "meso:local_id":"36420",
         "qs_pg:id":213587,
         "wd:id":"Q50241",
         "wk:page":"Muan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053896,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7368eefcd06ae1f338bf0c81d6de749a",
+    "wof:geomhash":"5ec7e12c27b93fee2aeca8b458b969b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890472363,
-    "wof:lastmodified":1690938328,
+    "wof:lastmodified":1695886630,
     "wof:name":"Muan",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/377/890472377.geojson
+++ b/data/890/472/377/890472377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.167727,
-    "geom:area_square_m":1632799135.766739,
+    "geom:area_square_m":1632799434.021927,
     "geom:bbox":"127.980367,37.812945,128.516006,38.383744",
     "geom:latitude":38.067943,
     "geom:longitude":128.264538,
@@ -144,16 +144,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289212,
+        "meso:local_id":"32390",
         "qs_pg:id":237314,
         "wd:id":"Q50318",
         "wk:page":"Inje County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053897,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5441028ecbc9f583902d402f32ec44be",
+    "wof:geomhash":"80e04c42d0cd546a6cb92ddbd24acb88",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890472377,
-    "wof:lastmodified":1690938333,
+    "wof:lastmodified":1695886631,
     "wof:name":"Inje",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/472/405/890472405.geojson
+++ b/data/890/472/405/890472405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079712,
-    "geom:area_square_m":802443798.377512,
+    "geom:area_square_m":802444203.802318,
     "geom:bbox":"128.570056,35.343793,129.028785,35.64572",
     "geom:latitude":35.499129,
     "geom:longitude":128.790877,
@@ -159,14 +159,16 @@
     "wof:concordances":{
         "gn:id":1841147,
         "gp:id":28289244,
+        "meso:local_id":"38080",
         "qs_pg:id":1202091
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053898,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1067896df797e80aa676887cc1770b4",
+    "wof:geomhash":"babd5f2de5b0ef4d4749d9ec78f94086",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890472405,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Miryang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/413/890472413.geojson
+++ b/data/890/472/413/890472413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08716,
-    "geom:area_square_m":866579689.958357,
+    "geom:area_square_m":866579276.116028,
     "geom:bbox":"126.886455,36.272158,127.283614,36.680392",
     "geom:latitude":36.480114,
     "geom:longitude":127.075981,
@@ -161,14 +161,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289175,
+        "meso:local_id":"34020",
         "qs_pg:id":1209112
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053898,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9cd7b1d4e7f2d5b90268a74d3db1151",
+    "wof:geomhash":"0dd9a57a52dac6a62df29f2a7b039218",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890472413,
-    "wof:lastmodified":1619481393,
+    "wof:lastmodified":1695886630,
     "wof:name":"Gongju",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/417/890472417.geojson
+++ b/data/890/472/417/890472417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086635,
-    "geom:area_square_m":846236448.112699,
+    "geom:area_square_m":846236445.974805,
     "geom:bbox":"127.268027,37.571709,127.619608,38.049403",
     "geom:latitude":37.819692,
     "geom:longitude":127.45168,
@@ -159,16 +159,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289167,
+        "meso:local_id":"31370",
         "qs_pg:id":1268285,
         "wd:id":"Q50203",
         "wk:page":"Gapyeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7358efa112bf6120775d23672f38767b",
+    "wof:geomhash":"597514a202398a3f5a16c4b0508d6e14",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890472417,
-    "wof:lastmodified":1690938336,
+    "wof:lastmodified":1695886632,
     "wof:name":"Gapyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/419/890472419.geojson
+++ b/data/890/472/419/890472419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114158,
-    "geom:area_square_m":1113988701.271218,
+    "geom:area_square_m":1113988722.093339,
     "geom:bbox":"127.512105,37.677049,128.025333,38.088407",
     "geom:latitude":37.891284,
     "geom:longitude":127.741703,
@@ -186,14 +186,16 @@
     "wof:concordances":{
         "gn:id":1845134,
         "gp:id":28289137,
+        "meso:local_id":"32010",
         "qs_pg:id":213551
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2421fb2acbf3d19ae1db715ed9987995",
+    "wof:geomhash":"82f38b4c7e61a7bf185a45058b0cde28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +205,7 @@
         }
     ],
     "wof:id":890472419,
-    "wof:lastmodified":1619481394,
+    "wof:lastmodified":1695886631,
     "wof:name":"Chuncheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/472/425/890472425.geojson
+++ b/data/890/472/425/890472425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044787,
-    "geom:area_square_m":452014258.838833,
+    "geom:area_square_m":452014584.978592,
     "geom:bbox":"126.85777,35.116906,127.112459,35.46646",
     "geom:latitude":35.292527,
     "geom:longitude":126.996772,
@@ -132,16 +132,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289142,
+        "meso:local_id":"36310",
         "qs_pg:id":224226,
         "wd:id":"Q50240",
         "wk:page":"Damyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c59fb0a18061d68d908bf20ff5f0a733",
+    "wof:geomhash":"3a8d54abeab9928431c66fd289c9365e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890472425,
-    "wof:lastmodified":1690938329,
+    "wof:lastmodified":1695886630,
     "wof:name":"Damyang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/472/439/890472439.geojson
+++ b/data/890/472/439/890472439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078557,
-    "geom:area_square_m":792097940.841003,
+    "geom:area_square_m":792097644.144011,
     "geom:bbox":"127.68399,35.216772,128.104155,35.578065",
     "geom:latitude":35.368672,
     "geom:longitude":127.885374,
@@ -132,16 +132,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289273,
+        "meso:local_id":"38370",
         "qs_pg:id":232432,
         "wd:id":"Q50248",
         "wk:page":"Sancheong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053900,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"050053574f944f8ba0e49ce78c701fcb",
+    "wof:geomhash":"0d46452fc0a3680dc3aa7bce58c070d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890472439,
-    "wof:lastmodified":1690938331,
+    "wof:lastmodified":1695886630,
     "wof:name":"Sancheong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/443/890472443.geojson
+++ b/data/890/472/443/890472443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131775,
-    "geom:area_square_m":1321103047.110863,
+    "geom:area_square_m":1321103141.099174,
     "geom:bbox":"128.971233,35.644908,129.521255,36.080387",
     "geom:latitude":35.827869,
     "geom:longitude":129.237245,
@@ -209,14 +209,16 @@
     "wof:concordances":{
         "gn:id":1833276,
         "gp:id":28289240,
+        "meso:local_id":"37020",
         "qs_pg:id":488345
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053900,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13b266c08526029918caa0f6b83b601c",
+    "wof:geomhash":"aa897e8bb11efa57f6597d0c2c9a8d0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -226,7 +228,7 @@
         }
     ],
     "wof:id":890472443,
-    "wof:lastmodified":1636497473,
+    "wof:lastmodified":1695886737,
     "wof:name":"Gyeongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/472/445/890472445.geojson
+++ b/data/890/472/445/890472445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024028,
-    "geom:area_square_m":235149963.385079,
+    "geom:area_square_m":235149829.223547,
     "geom:bbox":"126.520302,37.581296,126.801692,37.77953",
     "geom:latitude":37.677234,
     "geom:longitude":126.622065,
@@ -180,14 +180,16 @@
     "wof:concordances":{
         "gn:id":1842170,
         "gp:id":28289239,
+        "meso:local_id":"31230",
         "qs_pg:id":488346
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053900,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2f41f05ebac8089915e9c3c235774b4",
+    "wof:geomhash":"d921a11f52ac353d7acef0f64741e2eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +199,7 @@
         }
     ],
     "wof:id":890472445,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Gimpo",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/449/890472449.geojson
+++ b/data/890/472/449/890472449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005822,
-    "geom:area_square_m":57159882.02233,
+    "geom:area_square_m":57160051.445457,
     "geom:bbox":"126.6718,37.382,126.782113,37.482291",
     "geom:latitude":37.43308,
     "geom:longitude":126.72739,
@@ -92,16 +92,18 @@
     "wof:concordances":{
         "gn:id":8417651,
         "gp:id":28289256,
+        "meso:local_id":"23050",
         "qs_pg:id":239608,
         "wd:id":"Q6616970",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053900,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08a5a29abd9ce2f719b27ba2dd499479",
+    "wof:geomhash":"7fbb3647dbe39b20bdf28a4a958d350f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +113,7 @@
         }
     ],
     "wof:id":890472449,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Namdong",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/472/469/890472469.geojson
+++ b/data/890/472/469/890472469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071764,
-    "geom:area_square_m":721953402.375045,
+    "geom:area_square_m":721953336.519586,
     "geom:bbox":"127.586132,35.315509,127.880414,35.777085",
     "geom:latitude":35.551948,
     "geom:longitude":127.722866,
@@ -153,16 +153,18 @@
     "wof:concordances":{
         "gn:id":1844532,
         "gp:id":28289200,
+        "meso:local_id":"38380",
         "qs_pg:id":245451,
         "wd:id":"Q50339",
         "wk:page":"Hamyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cd80a95771003126e20f70af57a65506",
+    "wof:geomhash":"c9c4281daeb6da76be6a27d49694a82e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +174,7 @@
         }
     ],
     "wof:id":890472469,
-    "wof:lastmodified":1690938337,
+    "wof:lastmodified":1695886632,
     "wof:name":"Hamyang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/472/515/890472515.geojson
+++ b/data/890/472/515/890472515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005935,
-    "geom:area_square_m":59145062.426202,
+    "geom:area_square_m":59145194.273088,
     "geom:bbox":"127.196297,36.233367,127.288696,36.350864",
     "geom:latitude":36.293449,
     "geom:longitude":127.234673,
@@ -159,14 +159,16 @@
     "wof:concordances":{
         "gn:id":8419251,
         "gp:id":28289350,
+        "meso:local_id":"34070",
         "qs_pg:id":1203994
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053902,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4d766ffd9d34594cf94cfa86bca8e7c4",
+    "wof:geomhash":"0c4fc544efab4e434adc468a36a1a5c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890472515,
-    "wof:lastmodified":1619481395,
+    "wof:lastmodified":1695886632,
     "wof:name":"Gyeryong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/589/890472589.geojson
+++ b/data/890/472/589/890472589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004,
-    "geom:area_square_m":39268757.053859,
+    "geom:area_square_m":39268663.170759,
     "geom:bbox":"126.829295,37.40071,126.901068,37.494423",
     "geom:latitude":37.447332,
     "geom:longitude":126.866143,
@@ -172,14 +172,16 @@
     "wof:concordances":{
         "gn:id":8393794,
         "gp:id":28289191,
+        "meso:local_id":"31060",
         "qs_pg:id":1212660
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053910,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c3d02025a07aa933b38299e39f5768d",
+    "wof:geomhash":"18fe9b3fb0746733d738df547d30fa35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +191,7 @@
         }
     ],
     "wof:id":890472589,
-    "wof:lastmodified":1619481394,
+    "wof:lastmodified":1695886631,
     "wof:name":"Gwangmyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/472/595/890472595.geojson
+++ b/data/890/472/595/890472595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058407,
-    "geom:area_square_m":581719806.087671,
+    "geom:area_square_m":581719871.104359,
     "geom:bbox":"126.191193,36.17248,126.739861,36.530556",
     "geom:latitude":36.344388,
     "geom:longitude":126.593591,
@@ -157,15 +157,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289114,
+        "meso:local_id":"34030",
         "qs_pg:id":1264388,
         "wd:id":"Q50335"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053910,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eaeb2df293efdca72c18be515446bac2",
+    "wof:geomhash":"ce774d9d2e0d5945cd897f82118378cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         }
     ],
     "wof:id":890472595,
-    "wof:lastmodified":1690938327,
+    "wof:lastmodified":1695886628,
     "wof:name":"Boryeong",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/472/599/890472599.geojson
+++ b/data/890/472/599/890472599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079173,
-    "geom:area_square_m":781905964.404492,
+    "geom:area_square_m":781906161.119365,
     "geom:bbox":"128.218975,36.80091,128.650951,37.160667",
     "geom:latitude":36.995413,
     "geom:longitude":128.389801,
@@ -165,16 +165,18 @@
     "wof:concordances":{
         "gn:id":1834820,
         "gp:id":28289144,
+        "meso:local_id":"33380",
         "qs_pg:id":1250809,
         "wd:id":"Q50220",
         "wk:page":"Danyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053910,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28e31df9139f7072d56e5e621a1844a7",
+    "wof:geomhash":"221ccb084b6b294b05a66defc288300c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890472599,
-    "wof:lastmodified":1690938335,
+    "wof:lastmodified":1695886767,
     "wof:name":"Danyang",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/472/895/890472895.geojson
+++ b/data/890/472/895/890472895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001876,
-    "geom:area_square_m":18380099.259243,
+    "geom:area_square_m":18380190.928128,
     "geom:bbox":"126.903897,37.550719,126.968803,37.608046",
     "geom:latitude":37.577893,
     "geom:longitude":126.940904,
@@ -162,16 +162,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289283,
+        "meso:local_id":"11130",
         "qs_pg:id":1292747,
         "wd:id":"Q50408",
         "wk:page":"Seodaemun District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053930,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e1f1f2253b4c0ee553f9abd89a44e08",
+    "wof:geomhash":"bd5f2ea5a12fdf58b97f030759589df7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -181,7 +183,7 @@
         }
     ],
     "wof:id":890472895,
-    "wof:lastmodified":1690938330,
+    "wof:lastmodified":1695886630,
     "wof:name":"Seodaemun",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/472/985/890472985.geojson
+++ b/data/890/472/985/890472985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063284,
-    "geom:area_square_m":633549777.879523,
+    "geom:area_square_m":633549727.45968,
     "geom:bbox":"127.525663,35.787961,127.912258,36.071793",
     "geom:latitude":35.940546,
     "geom:longitude":127.713805,
@@ -137,15 +137,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289247,
+        "meso:local_id":"35330",
         "qs_pg:id":1315020,
         "wd:id":"Q50242"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053934,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"265f1419075fd203dc4ea86b71cbdf3d",
+    "wof:geomhash":"599f583a06aec6f8f1a761b42e9e4470",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +157,7 @@
         }
     ],
     "wof:id":890472985,
-    "wof:lastmodified":1690938335,
+    "wof:lastmodified":1695886631,
     "wof:name":"Muju",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/473/007/890473007.geojson
+++ b/data/890/473/007/890473007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007548,
-    "geom:area_square_m":75663718.884856,
+    "geom:area_square_m":75663647.087104,
     "geom:bbox":"128.597941,35.791108,128.729557,35.880011",
     "geom:latitude":35.836029,
     "geom:longitude":128.662985,
@@ -130,16 +130,18 @@
     "wof:concordances":{
         "gn:id":8419830,
         "gp:id":28289296,
+        "meso:local_id":"22060",
         "qs_pg:id":1316333,
         "wd:id":"Q50416",
         "wk:page":"Suseong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"18373dcf41f7a4e65441a2e3364cf6dd",
+    "wof:geomhash":"8c50e27235b5a9c78dabc45780a151a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +151,7 @@
         }
     ],
     "wof:id":890473007,
-    "wof:lastmodified":1690938343,
+    "wof:lastmodified":1695886770,
     "wof:name":"Suseong",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/473/031/890473031.geojson
+++ b/data/890/473/031/890473031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065499,
-    "geom:area_square_m":664935670.348514,
+    "geom:area_square_m":664935881.001197,
     "geom:bbox":"126.974474,34.636086,127.47628,34.988746",
     "geom:latitude":34.815086,
     "geom:longitude":127.164643,
@@ -161,16 +161,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1838737,
+        "meso:local_id":"36360",
         "qs_pg:id":276631,
         "wd:id":"Q50243",
         "wk:page":"Boseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053936,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a77786e0ca0e9778606a31b8c7e32e6",
+    "wof:geomhash":"c947ebf8bb11593e4c7864ee3ff66abe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
         }
     ],
     "wof:id":890473031,
-    "wof:lastmodified":1690938344,
+    "wof:lastmodified":1695886633,
     "wof:name":"Boseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/037/890473037.geojson
+++ b/data/890/473/037/890473037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07476,
-    "geom:area_square_m":760970608.729941,
+    "geom:area_square_m":760970248.244276,
     "geom:bbox":"127.082031,34.366222,127.548721,34.830358",
     "geom:latitude":34.595365,
     "geom:longitude":127.320098,
@@ -147,16 +147,18 @@
     "wof:concordances":{
         "gn:id":1842780,
         "gp:id":28289173,
+        "meso:local_id":"36350",
         "qs_pg:id":276643,
         "wd:id":"Q50211",
         "wk:page":"Goheung County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053936,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37f1f52a3a40aa10a83265a102f27f49",
+    "wof:geomhash":"6cce42057f6c717b99bb71adf9f0a0a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890473037,
-    "wof:lastmodified":1690938345,
+    "wof:lastmodified":1695886633,
     "wof:name":"Goheung",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/039/890473039.geojson
+++ b/data/890/473/039/890473039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095876,
-    "geom:area_square_m":989219116.985802,
+    "geom:area_square_m":989219071.144821,
     "geom:bbox":"126.144554,33.275815,126.969612,34.014584",
     "geom:latitude":33.445274,
     "geom:longitude":126.528237,
@@ -141,14 +141,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1846261,
+        "meso:local_id":"39010",
         "qs_pg:id":276648
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053936,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c0192e2267043485e2f0c1bf368ce19",
+    "wof:geomhash":"bda9bae0b5dbc80a0080c54c5a2c0c4e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +160,7 @@
         }
     ],
     "wof:id":890473039,
-    "wof:lastmodified":1636497473,
+    "wof:lastmodified":1695886737,
     "wof:name":"Jeju",
     "wof:parent_id":85673237,
     "wof:placetype":"county",

--- a/data/890/473/043/890473043.geojson
+++ b/data/890/473/043/890473043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003674,
-    "geom:area_square_m":36071219.423112,
+    "geom:area_square_m":36071146.316199,
     "geom:bbox":"126.960708,37.403523,127.047482,37.467745",
     "geom:latitude":37.434281,
     "geom:longitude":127.003915,
@@ -168,14 +168,16 @@
     "wof:concordances":{
         "gn:id":8393798,
         "gp:id":28289187,
+        "meso:local_id":"31110",
         "qs_pg:id":276860
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053936,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a891897f04738ad8341a7e3e8b17b67",
+    "wof:geomhash":"9c2372ff08c83fd063bbfc7a15293322",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +187,7 @@
         }
     ],
     "wof:id":890473043,
-    "wof:lastmodified":1619481398,
+    "wof:lastmodified":1695886634,
     "wof:name":"Gwacheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/175/890473175.geojson
+++ b/data/890/473/175/890473175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0384,
-    "geom:area_square_m":385414239.231063,
+    "geom:area_square_m":385414494.813622,
     "geom:bbox":"128.15927,35.605683,128.483145,35.853803",
     "geom:latitude":35.736763,
     "geom:longitude":128.308409,
@@ -148,16 +148,18 @@
     "wof:concordances":{
         "gn:id":1842555,
         "gp:id":28289176,
+        "meso:local_id":"37370",
         "qs_pg:id":320976,
         "wd:id":"Q50207",
         "wk:page":"Goryeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b9378154561297f8976d6a1bae11371",
+    "wof:geomhash":"a101a52dec3ed1e1b1a6560a228f9937",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
         }
     ],
     "wof:id":890473175,
-    "wof:lastmodified":1690938346,
+    "wof:lastmodified":1695886633,
     "wof:name":"Goryeong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/177/890473177.geojson
+++ b/data/890/473/177/890473177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09794,
-    "geom:area_square_m":984975978.327221,
+    "geom:area_square_m":984976567.467074,
     "geom:bbox":"127.954531,35.364958,128.375159,35.83449",
     "geom:latitude":35.577511,
     "geom:longitude":128.142793,
@@ -151,16 +151,18 @@
     "wof:concordances":{
         "gn:id":1844410,
         "gp:id":28289202,
+        "meso:local_id":"38400",
         "qs_pg:id":335706,
         "wd:id":"Q50341",
         "wk:page":"Hapcheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b09f417d075fb2205621985b7685b163",
+    "wof:geomhash":"233069764b6829864ac366e3c4669b1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890473177,
-    "wof:lastmodified":1690938352,
+    "wof:lastmodified":1695886768,
     "wof:name":"Hapcheon",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/179/890473179.geojson
+++ b/data/890/473/179/890473179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100517,
-    "geom:area_square_m":1004757435.675397,
+    "geom:area_square_m":1004757362.134446,
     "geom:bbox":"127.875737,35.829253,128.302687,36.264322",
     "geom:latitude":36.061087,
     "geom:longitude":128.078971,
@@ -155,14 +155,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289236,
+        "meso:local_id":"37030",
         "qs_pg:id":891211
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1e7e6e1977686cfde9412ded80eab4f",
+    "wof:geomhash":"55fa7fe8c32c095d0e4a788c98777e21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +174,7 @@
         }
     ],
     "wof:id":890473179,
-    "wof:lastmodified":1619481399,
+    "wof:lastmodified":1695886635,
     "wof:name":"Gimcheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/183/890473183.geojson
+++ b/data/890/473/183/890473183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088816,
-    "geom:area_square_m":873504788.722638,
+    "geom:area_square_m":873504688.549229,
     "geom:bbox":"127.742978,37.144224,128.222345,37.507702",
     "geom:latitude":37.309284,
     "geom:longitude":127.932249,
@@ -176,14 +176,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289310,
+        "meso:local_id":"32020",
         "qs_pg:id":348876
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96461bad0bcc6e163cf102755d567596",
+    "wof:geomhash":"7a9f73df08fa1292bbbb0f0841d2bd63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -193,7 +195,7 @@
         }
     ],
     "wof:id":890473183,
-    "wof:lastmodified":1636497474,
+    "wof:lastmodified":1695886737,
     "wof:name":"Wonju",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/189/890473189.geojson
+++ b/data/890/473/189/890473189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030779,
-    "geom:area_square_m":303254909.154476,
+    "geom:area_square_m":303254733.768623,
     "geom:bbox":"128.872679,37.062419,129.097332,37.345226",
     "geom:latitude":37.173839,
     "geom:longitude":128.981587,
@@ -180,14 +180,16 @@
     "wof:concordances":{
         "gn:id":8393711,
         "gp:id":28289300,
+        "meso:local_id":"32050",
         "qs_pg:id":351969
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"73e9505fd541508143da1903459a226f",
+    "wof:geomhash":"3166fcca64d897ed8a10b1ba66c9c4c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +199,7 @@
         }
     ],
     "wof:id":890473189,
-    "wof:lastmodified":1619481397,
+    "wof:lastmodified":1695886633,
     "wof:name":"Taebaek",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/191/890473191.geojson
+++ b/data/890/473/191/890473191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061787,
-    "geom:area_square_m":618818693.596818,
+    "geom:area_square_m":618818514.124607,
     "geom:bbox":"128.047437,35.776848,128.408389,36.056912",
     "geom:latitude":35.907826,
     "geom:longitude":128.235999,
@@ -141,16 +141,18 @@
     "wof:concordances":{
         "gn:id":1836130,
         "gp:id":28289287,
+        "meso:local_id":"37380",
         "qs_pg:id":351981,
         "wd:id":"Q50250",
         "wk:page":"Seongju County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5bc701c0d2dfa71763f51ae56220183b",
+    "wof:geomhash":"05189ff373df553274f8809e63505415",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890473191,
-    "wof:lastmodified":1690938347,
+    "wof:lastmodified":1695886771,
     "wof:name":"Seongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/193/890473193.geojson
+++ b/data/890/473/193/890473193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01271,
-    "geom:area_square_m":124855371.585792,
+    "geom:area_square_m":124855514.735987,
     "geom:bbox":"126.690391,37.332863,126.884646,37.471154",
     "geom:latitude":37.395679,
     "geom:longitude":126.796282,
@@ -167,14 +167,16 @@
     "wof:concordances":{
         "gn:id":1837364,
         "gp:id":28289290,
+        "meso:local_id":"31150",
         "qs_pg:id":351983
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff7b87df5ef27a6483d63ea6ca125879",
+    "wof:geomhash":"8add42ce65cbdff3013571f843225af0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890473193,
-    "wof:lastmodified":1619481396,
+    "wof:lastmodified":1695886632,
     "wof:name":"Siheung",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/197/890473197.geojson
+++ b/data/890/473/197/890473197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022213,
-    "geom:area_square_m":224537486.705137,
+    "geom:area_square_m":224537774.534794,
     "geom:bbox":"126.651539,35.069062,126.864362,35.259747",
     "geom:latitude":35.164863,
     "geom:longitude":126.755097,
@@ -118,16 +118,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1841791,
+        "meso:local_id":"24050",
         "qs_pg:id":356113,
         "wd:id":"Q50354",
         "wk:page":"Gwangsan District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ff1eb37dd134020f13e51b2fd57e6a63",
+    "wof:geomhash":"ba536281093a4ad181d2a44bb0ddbdc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -137,7 +139,7 @@
         }
     ],
     "wof:id":890473197,
-    "wof:lastmodified":1690938347,
+    "wof:lastmodified":1695886768,
     "wof:name":"Gwangsan",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/473/201/890473201.geojson
+++ b/data/890/473/201/890473201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002308,
-    "geom:area_square_m":22620070.028233,
+    "geom:area_square_m":22620106.926745,
     "geom:bbox":"126.859003,37.532407,126.965508,37.591901",
     "geom:latitude":37.560504,
     "geom:longitude":126.911648,
@@ -170,16 +170,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1841277,
+        "meso:local_id":"11140",
         "qs_pg:id":356123,
         "wd:id":"Q50388",
         "wk:page":"Mapo District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053943,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fb69fb732251338903bdd9fa0673189",
+    "wof:geomhash":"2f532859a0bea8c1d13131b1ca69bef0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +191,7 @@
         }
     ],
     "wof:id":890473201,
-    "wof:lastmodified":1690938351,
+    "wof:lastmodified":1695886634,
     "wof:name":"Mapo",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/215/890473215.geojson
+++ b/data/890/473/215/890473215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154381,
-    "geom:area_square_m":1532913987.314931,
+    "geom:area_square_m":1532914282.325575,
     "geom:bbox":"128.432068,36.29351,129.003046,36.822172",
     "geom:latitude":36.580904,
     "geom:longitude":128.781364,
@@ -188,14 +188,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289107,
+        "meso:local_id":"37040",
         "qs_pg:id":369322
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053944,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"509896a91c72f648e4fcc43c5fc64979",
+    "wof:geomhash":"3850f709766ef6dc07370fd719327edc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +207,7 @@
         }
     ],
     "wof:id":890473215,
-    "wof:lastmodified":1619481398,
+    "wof:lastmodified":1695886634,
     "wof:name":"Andong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/219/890473219.geojson
+++ b/data/890/473/219/890473219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053726,
-    "geom:area_square_m":546317759.902792,
+    "geom:area_square_m":546317623.713744,
     "geom:bbox":"127.193695,34.004555,127.906197,34.899612",
     "geom:latitude":34.67811,
     "geom:longitude":127.647561,
@@ -141,15 +141,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289335,
+        "meso:local_id":"36020",
         "qs_pg:id":369326,
         "wd:id":"Q50311"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"693a6bd0880c53d3ce7a889aa820ebb6",
+    "wof:geomhash":"529518745de032e121628ea8fa0b70d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -159,7 +161,7 @@
         }
     ],
     "wof:id":890473219,
-    "wof:lastmodified":1690938342,
+    "wof:lastmodified":1695886737,
     "wof:name":"Yeosu",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/223/890473223.geojson
+++ b/data/890/473/223/890473223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002274,
-    "geom:area_square_m":22275315.376059,
+    "geom:area_square_m":22275089.68377,
     "geom:bbox":"126.95104,37.566231,127.017853,37.632584",
     "geom:latitude":37.595887,
     "geom:longitude":126.978934,
@@ -186,15 +186,17 @@
     "wof:concordances":{
         "gn:id":1845581,
         "gp:id":28289225,
+        "meso:local_id":"11010",
         "qs_pg:id":371064,
         "wd:id":"Q36929"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"449d4ca0457f3b5a05407491551c09af",
+    "wof:geomhash":"c5b4b9971250b2aa16af2c7029eff816",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -204,7 +206,7 @@
         }
     ],
     "wof:id":890473223,
-    "wof:lastmodified":1690938349,
+    "wof:lastmodified":1695886634,
     "wof:name":"Jongno",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/229/890473229.geojson
+++ b/data/890/473/229/890473229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044728,
-    "geom:area_square_m":451502384.061651,
+    "geom:area_square_m":451502203.229704,
     "geom:bbox":"125.984528,35.167057,126.645471,35.43361",
     "geom:latitude":35.278635,
     "geom:longitude":126.455298,
@@ -154,16 +154,18 @@
     "wof:concordances":{
         "gn:id":1832500,
         "gp:id":28289329,
+        "meso:local_id":"36440",
         "qs_pg:id":372344,
         "wd:id":"Q50259",
         "wk:page":"Yeonggwang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2235246f98489bcf0b71500905506125",
+    "wof:geomhash":"88bdc05d9cc601f6a7c3c42bff0bbbfd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
         }
     ],
     "wof:id":890473229,
-    "wof:lastmodified":1690938341,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yeonggwang",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/231/890473231.geojson
+++ b/data/890/473/231/890473231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002405,
-    "geom:area_square_m":23586002.1618,
+    "geom:area_square_m":23586100.092858,
     "geom:bbox":"126.876927,37.484036,126.950921,37.548953",
     "geom:latitude":37.519858,
     "geom:longitude":126.910827,
@@ -148,16 +148,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1832536,
+        "meso:local_id":"11190",
         "qs_pg:id":372345,
         "wd:id":"Q50190",
         "wk:page":"Yeongdeungpo District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a5ea81258db0b50ed9ff472e9616678",
+    "wof:geomhash":"0b52cd701fa3abf1159a7c7a09a88561",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
         }
     ],
     "wof:id":890473231,
-    "wof:lastmodified":1690938350,
+    "wof:lastmodified":1695886634,
     "wof:name":"Yeongdeungpo",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/235/890473235.geojson
+++ b/data/890/473/235/890473235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00259,
-    "geom:area_square_m":25362472.306924,
+    "geom:area_square_m":25362369.154797,
     "geom:bbox":"126.980452,37.608665,127.049368,37.68562",
     "geom:latitude":37.643683,
     "geom:longitude":127.01193,
@@ -151,16 +151,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":1836339,
+        "meso:local_id":"11090",
         "qs_pg:id":372362,
         "wd:id":"Q50349",
         "wk:page":"Gangbuk District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a419d60689f6db061c646ef61b331db",
+    "wof:geomhash":"1cba11e3179cfea4afbfd525cc1a69b6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890473235,
-    "wof:lastmodified":1690938343,
+    "wof:lastmodified":1695886633,
     "wof:name":"Gangbuk",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/237/890473237.geojson
+++ b/data/890/473/237/890473237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077817,
-    "geom:area_square_m":788130911.109765,
+    "geom:area_square_m":788131358.996383,
     "geom:bbox":"126.834118,34.826877,127.202371,35.214951",
     "geom:latitude":35.008111,
     "geom:longitude":127.03517,
@@ -146,16 +146,18 @@
     "wof:concordances":{
         "gn:id":1843839,
         "gp:id":28289208,
+        "meso:local_id":"36370",
         "qs_pg:id":372363,
         "wd:id":"Q50345",
         "wk:page":"Hwasun County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053945,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f624c027050584908ffa7882999ab64",
+    "wof:geomhash":"03feab5c32969f7ff5966f4c2feececc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":890473237,
-    "wof:lastmodified":1690938351,
+    "wof:lastmodified":1695886634,
     "wof:name":"Hwasun",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/253/890473253.geojson
+++ b/data/890/473/253/890473253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001587,
-    "geom:area_square_m":15562359.113219,
+    "geom:area_square_m":15562475.817196,
     "geom:bbox":"127.009317,37.528213,127.073317,37.573913",
     "geom:latitude":37.551873,
     "geom:longitude":127.044351,
@@ -146,16 +146,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349528,
+        "meso:local_id":"11040",
         "qs_pg:id":381668,
         "wd:id":"Q50411",
         "wk:page":"Seongdong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053946,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e89d8c2542a257c40d9d87c71d3b2e81",
+    "wof:geomhash":"23da2c7384dbdeb18e2d9dffd5c52e9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":890473253,
-    "wof:lastmodified":1690938350,
+    "wof:lastmodified":1695886634,
     "wof:name":"Seongdong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/255/890473255.geojson
+++ b/data/890/473/255/890473255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003543,
-    "geom:area_square_m":34757192.290156,
+    "geom:area_square_m":34757009.027429,
     "geom:bbox":"127.066624,37.466184,127.165728,37.546274",
     "geom:latitude":37.505821,
     "geom:longitude":127.116212,
@@ -149,16 +149,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349536,
+        "meso:local_id":"11240",
         "qs_pg:id":381669,
         "wd:id":"Q50415",
         "wk:page":"Songpa District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053946,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe4816e3eab67464a5d78126aeae0fe3",
+    "wof:geomhash":"48bf05d0d8b310ad56c0fc789576c4ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +170,7 @@
         }
     ],
     "wof:id":890473255,
-    "wof:lastmodified":1690938352,
+    "wof:lastmodified":1695886634,
     "wof:name":"Songpa",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/289/890473289.geojson
+++ b/data/890/473/289/890473289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05184,
-    "geom:area_square_m":522962900.748209,
+    "geom:area_square_m":522962683.581699,
     "geom:bbox":"126.584476,35.190646,126.927481,35.489536",
     "geom:latitude":35.330023,
     "geom:longitude":126.769574,
@@ -145,16 +145,18 @@
     "wof:concordances":{
         "gn:id":1846368,
         "gp:id":28289214,
+        "meso:local_id":"36450",
         "qs_pg:id":1031703,
         "wd:id":"Q50320",
         "wk:page":"Jangseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053947,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32985b72f20dbba49ccaeeab42b903b1",
+    "wof:geomhash":"7fc10485f2a2418394c7bd2d047dc8ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -164,7 +166,7 @@
         }
     ],
     "wof:id":890473289,
-    "wof:lastmodified":1690938342,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jangseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/295/890473295.geojson
+++ b/data/890/473/295/890473295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009597,
-    "geom:area_square_m":94119672.082893,
+    "geom:area_square_m":94119884.853015,
     "geom:bbox":"127.142209,37.467544,127.28895,37.594828",
     "geom:latitude":37.523864,
     "geom:longitude":127.208096,
@@ -175,14 +175,16 @@
     "wof:concordances":{
         "gn:id":8393790,
         "gp:id":28289201,
+        "meso:local_id":"31180",
         "qs_pg:id":1032263
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053947,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"70248e9fd937002a3f570c7b2bdc01a0",
+    "wof:geomhash":"9bbe36b583dd66de2a628072d0934dac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +194,7 @@
         }
     ],
     "wof:id":890473295,
-    "wof:lastmodified":1619481396,
+    "wof:lastmodified":1695886633,
     "wof:name":"Hanam",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/315/890473315.geojson
+++ b/data/890/473/315/890473315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004758,
-    "geom:area_square_m":48311427.056998,
+    "geom:area_square_m":48311437.28225,
     "geom:bbox":"126.289528,34.745419,126.463459,34.846606",
     "geom:latitude":34.804331,
     "geom:longitude":126.386626,
@@ -156,15 +156,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289245,
+        "meso:local_id":"36010",
         "qs_pg:id":493557,
         "wd:id":"Q50262"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3389e1b5330212f2b026d60f690985dd",
+    "wof:geomhash":"6265597471263d431e65c2b0d01cfd89",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +176,7 @@
         }
     ],
     "wof:id":890473315,
-    "wof:lastmodified":1690938346,
+    "wof:lastmodified":1695886737,
     "wof:name":"Mokpo",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/319/890473319.geojson
+++ b/data/890/473/319/890473319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005039,
-    "geom:area_square_m":49448445.3409,
+    "geom:area_square_m":49448368.608099,
     "geom:bbox":"126.980327,37.42764,127.099554,37.528037",
     "geom:latitude":37.473736,
     "geom:longitude":127.034557,
@@ -152,16 +152,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8349535,
+        "meso:local_id":"11220",
         "qs_pg:id":1042695,
         "wd:id":"Q20395",
         "wk:page":"Seocho District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d93d3642737d64d36986f32bb57a89f",
+    "wof:geomhash":"126780f209d86d4205bc277decf3ee6f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +173,7 @@
         }
     ],
     "wof:id":890473319,
-    "wof:lastmodified":1690938354,
+    "wof:lastmodified":1695886635,
     "wof:name":"Seocho",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/321/890473321.geojson
+++ b/data/890/473/321/890473321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01187,
-    "geom:area_square_m":119943400.550179,
+    "geom:area_square_m":119943635.156345,
     "geom:bbox":"126.839721,35.116375,127.021746,35.259855",
     "geom:latitude":35.193433,
     "geom:longitude":126.929113,
@@ -270,16 +270,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462136,
+        "meso:local_id":"24040",
         "qs_pg:id":1042739,
         "wd:id":"Q6497681",
         "wk:page":"Buk-gu"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4739ce6cb4c3f6df6e210caa1102294",
+    "wof:geomhash":"28c9fb8aab78aea364b3d97e83de50e4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -289,7 +291,7 @@
         }
     ],
     "wof:id":890473321,
-    "wof:lastmodified":1619481399,
+    "wof:lastmodified":1695886635,
     "wof:name":"Buk",
     "wof:parent_id":85673199,
     "wof:placetype":"county",

--- a/data/890/473/335/890473335.geojson
+++ b/data/890/473/335/890473335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004181,
-    "geom:area_square_m":41196281.17419,
+    "geom:area_square_m":41196463.855101,
     "geom:bbox":"126.999858,37.124977,127.104492,37.201937",
     "geom:latitude":37.164052,
     "geom:longitude":127.053,
@@ -180,14 +180,16 @@
     "wof:concordances":{
         "gn:id":8393795,
         "gp:id":28289264,
+        "meso:local_id":"31140",
         "qs_pg:id":1077140
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053949,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c9950d53e4ec60e09b10c3c05b818d2",
+    "wof:geomhash":"3e234203920a91f7ecad26efadc121f9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +199,7 @@
         }
     ],
     "wof:id":890473335,
-    "wof:lastmodified":1619481397,
+    "wof:lastmodified":1695886634,
     "wof:name":"Osan",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/473/345/890473345.geojson
+++ b/data/890/473/345/890473345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057989,
-    "geom:area_square_m":579210224.391115,
+    "geom:area_square_m":579209753.466204,
     "geom:bbox":"127.315708,35.979611,127.63861,36.273396",
     "geom:latitude":36.120592,
     "geom:longitude":127.479496,
@@ -156,16 +156,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289170,
+        "meso:local_id":"34310",
         "qs_pg:id":400703,
         "wd:id":"Q50216",
         "wk:page":"Geumsan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053949,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b09d57f3438c80d554fce75ced0e9ea",
+    "wof:geomhash":"6e90e6080678b117b0d1588ee9e5d4e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         }
     ],
     "wof:id":890473345,
-    "wof:lastmodified":1690938353,
+    "wof:lastmodified":1695886634,
     "wof:name":"Geumsan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/473/363/890473363.geojson
+++ b/data/890/473/363/890473363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11346,
-    "geom:area_square_m":1117420798.424217,
+    "geom:area_square_m":1117420758.037571,
     "geom:bbox":"128.113087,37.030054,128.898632,37.410739",
     "geom:latitude":37.204747,
     "geom:longitude":128.503233,
@@ -156,16 +156,18 @@
     "wof:concordances":{
         "gn:id":8393710,
         "gp:id":28289330,
+        "meso:local_id":"32330",
         "qs_pg:id":407509,
         "wd:id":"Q50306",
         "wk:page":"Yeongwol County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053950,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e7ca200faf1200fc4e1cab2e8bba10e7",
+    "wof:geomhash":"5f0a1f604f5a8c063352c6b0802e491d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         }
     ],
     "wof:id":890473363,
-    "wof:lastmodified":1690938340,
+    "wof:lastmodified":1695886633,
     "wof:name":"Yeongwol",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/385/890473385.geojson
+++ b/data/890/473/385/890473385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079214,
-    "geom:area_square_m":786090011.7668,
+    "geom:area_square_m":786089662.3399,
     "geom:bbox":"127.27857,36.406108,127.771135,36.78228",
     "geom:latitude":36.626052,
     "geom:longitude":127.506882,
@@ -144,16 +144,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289134,
+        "meso:local_id":"33310",
         "qs_pg:id":22276,
         "wd:id":"Q50333",
         "wk:page":"Cheongwon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053951,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8e547b8a98ed7bad59b489243fb99a9",
+    "wof:geomhash":"9fe896e81ec649d6bebfd15a73e1c319",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890473385,
-    "wof:lastmodified":1690938346,
+    "wof:lastmodified":1695886634,
     "wof:name":"Cheongwon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/473/483/890473483.geojson
+++ b/data/890/473/483/890473483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002711,
-    "geom:area_square_m":26571693.377592,
+    "geom:area_square_m":26571651.185226,
     "geom:bbox":"127.111223,37.517202,127.186828,37.585412",
     "geom:latitude":37.551946,
     "geom:longitude":127.148104,
@@ -163,16 +163,18 @@
     "wof:concordances":{
         "gn:id":1843175,
         "gp:id":28289160,
+        "meso:local_id":"11250",
         "qs_pg:id":492061,
         "wd:id":"Q50348",
         "wk:page":"Gangdong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053954,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"18aa27b9b5b7f2871dfee2e2ef1d060b",
+    "wof:geomhash":"2863b1c0b7445302c3b4bdb7ca0cd73b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +184,7 @@
         }
     ],
     "wof:id":890473483,
-    "wof:lastmodified":1690938342,
+    "wof:lastmodified":1695886633,
     "wof:name":"Gangdong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/489/890473489.geojson
+++ b/data/890/473/489/890473489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040776,
-    "geom:area_square_m":412771048.017603,
+    "geom:area_square_m":412771292.82407,
     "geom:bbox":"127.878564,34.886223,128.191512,35.161414",
     "geom:latitude":35.048825,
     "geom:longitude":128.038725,
@@ -140,14 +140,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289270,
+        "meso:local_id":"38060",
         "qs_pg:id":425056
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053954,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eed1a9e2146fc7597fa05fe74dd2f3cb",
+    "wof:geomhash":"fa9d5280bd13854c0d86e9b9c41c6513",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890473489,
-    "wof:lastmodified":1619481398,
+    "wof:lastmodified":1695886634,
     "wof:name":"Sacheon",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/513/890473513.geojson
+++ b/data/890/473/513/890473513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123474,
-    "geom:area_square_m":1213227159.668649,
+    "geom:area_square_m":1213227801.417805,
     "geom:bbox":"128.507687,37.147165,128.991554,37.59352",
     "geom:latitude":37.379334,
     "geom:longitude":128.740475,
@@ -184,16 +184,18 @@
     "wof:concordances":{
         "gn:id":1845515,
         "gp:id":28289218,
+        "meso:local_id":"32350",
         "qs_pg:id":468997,
         "wd:id":"Q50323",
         "wk:page":"Jeongseon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053955,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"132fdc493b9a21c36e1ca1b9d152a2e0",
+    "wof:geomhash":"4c61fe428d4ea254c5bbdd9ceb9056c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +205,7 @@
         }
     ],
     "wof:id":890473513,
-    "wof:lastmodified":1690938353,
+    "wof:lastmodified":1695886769,
     "wof:name":"Jeongseon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/525/890473525.geojson
+++ b/data/890/473/525/890473525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061805,
-    "geom:area_square_m":616324948.972479,
+    "geom:area_square_m":616325040.935854,
     "geom:bbox":"126.681915,36.072251,127.071169,36.384328",
     "geom:latitude":36.247511,
     "geom:longitude":126.857299,
@@ -172,16 +172,18 @@
     "wof:concordances":{
         "gn:id":1838507,
         "gp:id":28289125,
+        "meso:local_id":"34330",
         "qs_pg:id":488300,
         "wd:id":"Q50247",
         "wk:page":"Buyeo County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053955,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1036373e026fac5381bd1ca63e647d0",
+    "wof:geomhash":"008bfe55d55a12b0e103e7f7aee8fe99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +193,7 @@
         }
     ],
     "wof:id":890473525,
-    "wof:lastmodified":1690938353,
+    "wof:lastmodified":1695886766,
     "wof:name":"Buyeo",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/473/531/890473531.geojson
+++ b/data/890/473/531/890473531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050306,
-    "geom:area_square_m":504489906.358661,
+    "geom:area_square_m":504489886.560732,
     "geom:bbox":"126.683693,35.663897,127.08675,35.920572",
     "geom:latitude":35.804735,
     "geom:longitude":126.910968,
@@ -159,14 +159,16 @@
     "wof:concordances":{
         "gn:id":1842211,
         "gp:id":28289238,
+        "meso:local_id":"35060",
         "qs_pg:id":488323
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"253a6ec5581b57416635bca53bce73a5",
+    "wof:geomhash":"497fd1dcc3a0cd6ec17ba81c706ddb43",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890473531,
-    "wof:lastmodified":1619481398,
+    "wof:lastmodified":1695886635,
     "wof:name":"Gimje",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/473/533/890473533.geojson
+++ b/data/890/473/533/890473533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001458,
-    "geom:area_square_m":14283074.876895,
+    "geom:area_square_m":14283075.855276,
     "geom:bbox":"127.022883,37.560401,127.080772,37.607154",
     "geom:latitude":37.582687,
     "geom:longitude":127.055271,
@@ -170,16 +170,18 @@
     "wof:concordances":{
         "gn:id":1834328,
         "gp:id":28289152,
+        "meso:local_id":"11060",
         "qs_pg:id":492059,
         "wd:id":"Q50382",
         "wk:page":"Dongdaemun District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae9bf1905f19d55bbb1c5098f8bae7e5",
+    "wof:geomhash":"6b9eb5b46333e51c60d3ee9d650d0f5d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +191,7 @@
         }
     ],
     "wof:id":890473533,
-    "wof:lastmodified":1690938339,
+    "wof:lastmodified":1695886632,
     "wof:name":"Dongdaemun",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/547/890473547.geojson
+++ b/data/890/473/547/890473547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060054,
-    "geom:area_square_m":610670217.790591,
+    "geom:area_square_m":610669775.488967,
     "geom:bbox":"126.794447,34.423007,127.048633,34.877979",
     "geom:latitude":34.678064,
     "geom:longitude":126.923641,
@@ -132,16 +132,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289213,
+        "meso:local_id":"36380",
         "qs_pg:id":506254,
         "wd:id":"Q50322",
         "wk:page":"Jangheung County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"250b9eadc11cbbb1f959ec0d395c1f68",
+    "wof:geomhash":"06c759a7e91e5031020f79f84f68ae7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890473547,
-    "wof:lastmodified":1690938352,
+    "wof:lastmodified":1695886635,
     "wof:name":"Jangheung",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/555/890473555.geojson
+++ b/data/890/473/555/890473555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012548,
-    "geom:area_square_m":123493201.955072,
+    "geom:area_square_m":123493472.809852,
     "geom:bbox":"125.746223,36.920361,126.552826,37.559502",
     "geom:latitude":37.259719,
     "geom:longitude":126.258958,
@@ -146,16 +146,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289263,
+        "meso:local_id":"23320",
         "qs_pg:id":896810,
         "wd:id":"Q50310",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd05f9ade3fa1e186c765719bbd268ee",
+    "wof:geomhash":"20e50dcf3fda1948168cd060f3fc3c1f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
         }
     ],
     "wof:id":890473555,
-    "wof:lastmodified":1690938347,
+    "wof:lastmodified":1695886737,
     "wof:name":"Ongjin",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/473/557/890473557.geojson
+++ b/data/890/473/557/890473557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07631,
-    "geom:area_square_m":741181441.681898,
+    "geom:area_square_m":741181824.668659,
     "geom:bbox":"127.108386,38.092662,127.6081,38.335999",
     "geom:latitude":38.233541,
     "geom:longitude":127.356047,
@@ -127,16 +127,18 @@
     "wof:concordances":{
         "gn:id":1845344,
         "gp:id":28289129,
+        "meso:local_id":"32360",
         "qs_pg:id":896864,
         "wd:id":"Q490109",
         "wk:page":"Chorwon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"60ea3d722e0c4e7e088c441ce3e1ad75",
+    "wof:geomhash":"3f98142d206f2fd6c4b54be78f3ad9a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -146,7 +148,7 @@
         }
     ],
     "wof:id":890473557,
-    "wof:lastmodified":1690938340,
+    "wof:lastmodified":1695886633,
     "wof:name":"Gongju",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/559/890473559.geojson
+++ b/data/890/473/559/890473559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085184,
-    "geom:area_square_m":850411566.382361,
+    "geom:area_square_m":850412016.029288,
     "geom:bbox":"127.589867,36.012873,128.056016,36.314335",
     "geom:latitude":36.160755,
     "geom:longitude":127.816348,
@@ -157,16 +157,18 @@
     "wof:concordances":{
         "gn:id":1832561,
         "gp:id":28289327,
+        "meso:local_id":"33340",
         "qs_pg:id":897828,
         "wd:id":"Q50261",
         "wk:page":"Yeongdong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdd0d329553537550f45034779de0503",
+    "wof:geomhash":"ed4034be4707100e2a61f044b5069d94",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890473559,
-    "wof:lastmodified":1690938340,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yeongdong",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/473/561/890473561.geojson
+++ b/data/890/473/561/890473561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003185,
-    "geom:area_square_m":31193030.77373,
+    "geom:area_square_m":31192960.158358,
     "geom:bbox":"126.893338,37.575804,126.971633,37.659216",
     "geom:latitude":37.620218,
     "geom:longitude":126.930817,
@@ -154,16 +154,18 @@
     "wof:concordances":{
         "gn:id":1833594,
         "gp:id":28289158,
+        "meso:local_id":"11120",
         "qs_pg:id":898571,
         "wd:id":"Q50432",
         "wk:page":"Eunpyeong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"983df2d7b316eaa34e3b7c0767b6bd6a",
+    "wof:geomhash":"01a66aed24d3a97f0312f0920046b9d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
         }
     ],
     "wof:id":890473561,
-    "wof:lastmodified":1690938340,
+    "wof:lastmodified":1695886633,
     "wof:name":"Eunpyeong",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/473/621/890473621.geojson
+++ b/data/890/473/621/890473621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052221,
-    "geom:area_square_m":525630420.196201,
+    "geom:area_square_m":525630573.516656,
     "geom:bbox":"128.349703,35.372375,128.652942,35.68374",
     "geom:latitude":35.509666,
     "geom:longitude":128.494061,
@@ -159,16 +159,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289126,
+        "meso:local_id":"38330",
         "qs_pg:id":965347,
         "wd:id":"Q50328",
         "wk:page":"Changnyeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053959,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ded010f7f8944522663817cae57ae3c",
+    "wof:geomhash":"4f05c76abeff59569d8027f7c463b481",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890473621,
-    "wof:lastmodified":1690938342,
+    "wof:lastmodified":1695886633,
     "wof:name":"Changnyeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/473/623/890473623.geojson
+++ b/data/890/473/623/890473623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101871,
-    "geom:area_square_m":999208512.077916,
+    "geom:area_square_m":999208435.368152,
     "geom:bbox":"127.761523,37.303083,128.304988,37.681405",
     "geom:latitude":37.510429,
     "geom:longitude":128.078336,
@@ -150,16 +150,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289203,
+        "meso:local_id":"32320",
         "qs_pg:id":965395,
         "wd:id":"Q50347",
         "wk:page":"Hoengseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053959,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c7a13871f6a1e004b5ceec28444bc60",
+    "wof:geomhash":"e3016f4e3beb3acb5592529d559ef8a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890473623,
-    "wof:lastmodified":1690938349,
+    "wof:lastmodified":1695886635,
     "wof:name":"Hoengseong",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/473/661/890473661.geojson
+++ b/data/890/473/661/890473661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04809,
-    "geom:area_square_m":489329487.066967,
+    "geom:area_square_m":489329944.505255,
     "geom:bbox":"126.659832,34.440749,126.88397,34.787054",
     "geom:latitude":34.623531,
     "geom:longitude":126.77427,
@@ -144,16 +144,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289162,
+        "meso:local_id":"36390",
         "qs_pg:id":974310,
         "wd:id":"Q50204",
         "wk:page":"Gangjin County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053961,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b06154ff17a6f6a1bc27dd0715c3b76a",
+    "wof:geomhash":"181f96f37e4703d6048fcfd239aef0a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890473661,
-    "wof:lastmodified":1690938344,
+    "wof:lastmodified":1695886634,
     "wof:name":"Gangjin",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/473/713/890473713.geojson
+++ b/data/890/473/713/890473713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08259,
-    "geom:area_square_m":818829164.39703,
+    "geom:area_square_m":818829654.564386,
     "geom:bbox":"128.982639,36.493866,129.315612,36.882678",
     "geom:latitude":36.698021,
     "geom:longitude":129.146564,
@@ -144,16 +144,18 @@
     "wof:concordances":{
         "gn:id":8419823,
         "gp:id":28289331,
+        "meso:local_id":"37340",
         "qs_pg:id":988866,
         "wd:id":"Q50263",
         "wk:page":"Yeongyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053962,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b398fde95b30984d2d80fccd00e71f38",
+    "wof:geomhash":"27744bf51325db5be8521f02bb9237ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890473713,
-    "wof:lastmodified":1690938346,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yeongyang",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/473/945/890473945.geojson
+++ b/data/890/473/945/890473945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085464,
-    "geom:area_square_m":846510539.902711,
+    "geom:area_square_m":846510453.468059,
     "geom:bbox":"127.620976,36.601877,128.074578,36.948873",
     "geom:latitude":36.771083,
     "geom:longitude":127.830461,
@@ -165,16 +165,18 @@
     "wof:concordances":{
         "gn:id":1842799,
         "gp:id":28289172,
+        "meso:local_id":"33360",
         "qs_pg:id":1001642,
         "wd:id":"Q50213",
         "wk:page":"Goesan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053971,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8bb0b46507b0decc6b663ba9595bbc44",
+    "wof:geomhash":"7b31df18261537c5145708c63bbe662a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890473945,
-    "wof:lastmodified":1690938354,
+    "wof:lastmodified":1695886768,
     "wof:name":"Goesan",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/474/133/890474133.geojson
+++ b/data/890/474/133/890474133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006934,
-    "geom:area_square_m":69001101.486601,
+    "geom:area_square_m":69000911.926519,
     "geom:bbox":"127.392518,36.34452,127.502582,36.478748",
     "geom:latitude":36.412784,
     "geom:longitude":127.440197,
@@ -117,16 +117,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289139,
+        "meso:local_id":"25050",
         "qs_pg:id":1006311,
         "wd:id":"Q50371",
         "wk:page":"Daedeok District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053978,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3a43cefbbc0228d8acdfe608ff2e61f",
+    "wof:geomhash":"f2865ccbc3ed0193ad180b8b3832207a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +138,7 @@
         }
     ],
     "wof:id":890474133,
-    "wof:lastmodified":1690938355,
+    "wof:lastmodified":1695886767,
     "wof:name":"Daedeok",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/890/474/443/890474443.geojson
+++ b/data/890/474/443/890474443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055391,
-    "geom:area_square_m":552762463.899929,
+    "geom:area_square_m":552762832.2599,
     "geom:bbox":"126.983601,36.063575,127.337178,36.339",
     "geom:latitude":36.192039,
     "geom:longitude":127.158565,
@@ -152,14 +152,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289260,
+        "meso:local_id":"34060",
         "qs_pg:id":896811
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053989,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2056ddd817aaff07168faa7b14417c21",
+    "wof:geomhash":"bb405d49dad4cf14ccf6277ea56264a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474443,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886635,
     "wof:name":"Nonsan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/447/890474447.geojson
+++ b/data/890/474/447/890474447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003971,
-    "geom:area_square_m":38952506.156219,
+    "geom:area_square_m":38952665.684443,
     "geom:bbox":"127.014615,37.457786,127.126302,37.546687",
     "geom:latitude":37.498869,
     "geom:longitude":127.062491,
@@ -270,16 +270,18 @@
     "wof:concordances":{
         "gn:id":1843140,
         "gp:id":28289163,
+        "meso:local_id":"11230",
         "qs_pg:id":897178,
         "wd:id":"Q20398",
         "wk:page":"Gangnam District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053989,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b398e11504b8258a63bab580874c4a2",
+    "wof:geomhash":"9fb9f576c079dbc36517329ea83eeea9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -289,7 +291,7 @@
         }
     ],
     "wof:id":890474447,
-    "wof:lastmodified":1690938356,
+    "wof:lastmodified":1695886635,
     "wof:name":"Gangnam",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/474/479/890474479.geojson
+++ b/data/890/474/479/890474479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121855,
-    "geom:area_square_m":1204373326.885971,
+    "geom:area_square_m":1204373016.328215,
     "geom:bbox":"128.63967,36.746809,129.187354,37.100455",
     "geom:latitude":36.93552,
     "geom:longitude":128.914738,
@@ -160,16 +160,18 @@
     "wof:concordances":{
         "gn:id":1838893,
         "gp:id":28289113,
+        "meso:local_id":"37410",
         "qs_pg:id":1056853,
         "wd:id":"Q50245",
         "wk:page":"Bonghwa County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053991,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c5b22f4deb963643370819e6ce1872c",
+    "wof:geomhash":"69aa817ba9f9abc18818c777e6bc112b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":890474479,
-    "wof:lastmodified":1690938357,
+    "wof:lastmodified":1695886766,
     "wof:name":"Bonghwa",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/513/890474513.geojson
+++ b/data/890/474/513/890474513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041091,
-    "geom:area_square_m":414719926.456347,
+    "geom:area_square_m":414719677.773499,
     "geom:bbox":"128.277513,35.16485,128.58846,35.400404",
     "geom:latitude":35.291795,
     "geom:longitude":128.432584,
@@ -150,16 +150,18 @@
     "wof:concordances":{
         "gn:id":1844557,
         "gp:id":28289198,
+        "meso:local_id":"38320",
         "qs_pg:id":1062387,
         "wd:id":"Q50338",
         "wk:page":"Haman County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053992,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a00839e2004afd242d98104ba345ccd",
+    "wof:geomhash":"fba2c22aff6ea7c63906a72085861a5c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474513,
-    "wof:lastmodified":1690938364,
+    "wof:lastmodified":1695886768,
     "wof:name":"Haman",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/515/890474515.geojson
+++ b/data/890/474/515/890474515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04219,
-    "geom:area_square_m":428018431.318226,
+    "geom:area_square_m":428018358.331233,
     "geom:bbox":"128.455368,34.53286,128.769577,35.062084",
     "geom:latitude":34.869481,
     "geom:longitude":128.623191,
@@ -155,14 +155,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289234,
+        "meso:local_id":"38090",
         "qs_pg:id":1063264
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053992,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"18fb3da5d35a336b662234956c924805",
+    "wof:geomhash":"26b8239108b1aea1df17131355c34812",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +174,7 @@
         }
     ],
     "wof:id":890474515,
-    "wof:lastmodified":1619481401,
+    "wof:lastmodified":1695886636,
     "wof:name":"Geoje",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/581/890474581.geojson
+++ b/data/890/474/581/890474581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027773,
-    "geom:area_square_m":281934207.79331,
+    "geom:area_square_m":281934618.104984,
     "geom:bbox":"128.082062,34.497082,128.586227,34.983627",
     "geom:latitude":34.818599,
     "geom:longitude":128.373458,
@@ -162,14 +162,16 @@
     "wof:concordances":{
         "gn:id":1845017,
         "gp:id":28289301,
+        "meso:local_id":"38050",
         "qs_pg:id":1077141
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053995,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f7c9ada13fba2c83623757ce916ac91",
+    "wof:geomhash":"72aac9d9182847ae70551717328be398",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":890474581,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886635,
     "wof:name":"Tongyeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/583/890474583.geojson
+++ b/data/890/474/583/890474583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046928,
-    "geom:area_square_m":459352526.616446,
+    "geom:area_square_m":459352474.592224,
     "geom:bbox":"127.080538,37.504817,127.381702,37.781735",
     "geom:latitude":37.663932,
     "geom:longitude":127.244507,
@@ -168,14 +168,16 @@
     "wof:concordances":{
         "gn:id":1840374,
         "gp:id":28289259,
+        "meso:local_id":"31130",
         "qs_pg:id":1077142
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053995,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c2855b622c02934437ef67ffb45ed7a",
+    "wof:geomhash":"5cf9f487ce4fa135076a03ad5996b23a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +187,7 @@
         }
     ],
     "wof:id":890474583,
-    "wof:lastmodified":1619481401,
+    "wof:lastmodified":1695886637,
     "wof:name":"Namyangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/585/890474585.geojson
+++ b/data/890/474/585/890474585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003775,
-    "geom:area_square_m":37104907.58063,
+    "geom:area_square_m":37104921.850986,
     "geom:bbox":"126.874252,37.30517,126.972741,37.382232",
     "geom:latitude":37.344631,
     "geom:longitude":126.9233,
@@ -175,14 +175,16 @@
     "wof:concordances":{
         "gn:id":8393793,
         "gp:id":28289181,
+        "meso:local_id":"31160",
         "qs_pg:id":1078802
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053995,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"04fca54279346b491840c01a55b725d6",
+    "wof:geomhash":"90dbcf2dc43453650d5ce59fba62b1be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +194,7 @@
         }
     ],
     "wof:id":890474585,
-    "wof:lastmodified":1619481401,
+    "wof:lastmodified":1695886637,
     "wof:name":"Gunpo",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/591/890474591.geojson
+++ b/data/890/474/591/890474591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003319,
-    "geom:area_square_m":32513304.4518,
+    "geom:area_square_m":32513594.28056,
     "geom:bbox":"127.102217,37.560278,127.16912,37.648356",
     "geom:latitude":37.601993,
     "geom:longitude":127.132574,
@@ -171,14 +171,16 @@
     "wof:concordances":{
         "gn:id":8393803,
         "gp:id":28289184,
+        "meso:local_id":"31120",
         "qs_pg:id":1078805
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1ed96cd747f39030c0a75aaa48d6266",
+    "wof:geomhash":"20a169a9b3a3ab7e1e112fa944dda256",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +190,7 @@
         }
     ],
     "wof:id":890474591,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886636,
     "wof:name":"Guri",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/597/890474597.geojson
+++ b/data/890/474/597/890474597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048496,
-    "geom:area_square_m":488791602.752789,
+    "geom:area_square_m":488791178.929498,
     "geom:bbox":"128.870716,35.274976,129.220001,35.531884",
     "geom:latitude":35.401054,
     "geom:longitude":129.043496,
@@ -162,14 +162,16 @@
     "wof:concordances":{
         "gn:id":1832824,
         "gp:id":28289315,
+        "meso:local_id":"38100",
         "qs_pg:id":1078808
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"662e9b8de692c61e7ab4e66584014322",
+    "wof:geomhash":"21c34e0fc707ac920e168fc8c7582ec3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":890474597,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886636,
     "wof:name":"Yangsan",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/599/890474599.geojson
+++ b/data/890/474/599/890474599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017597,
-    "geom:area_square_m":175185177.464413,
+    "geom:area_square_m":175185134.936572,
     "geom:bbox":"127.249035,36.262177,127.419822,36.502324",
     "geom:latitude":36.377523,
     "geom:longitude":127.334024,
@@ -121,16 +121,18 @@
     "wof:concordances":{
         "gn:id":8419684,
         "gp:id":28289339,
+        "meso:local_id":"25040",
         "qs_pg:id":1078809,
         "wd:id":"Q50431",
         "wk:page":"Yuseong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"71d903b9157a1bd9ebab68bf1b9d2c7f",
+    "wof:geomhash":"72a4181f864abe205cb102a28b4e7742",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +142,7 @@
         }
     ],
     "wof:id":890474599,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886636,
     "wof:name":"Yuseong",
     "wof:parent_id":85673207,
     "wof:placetype":"county",

--- a/data/890/474/617/890474617.geojson
+++ b/data/890/474/617/890474617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003699,
-    "geom:area_square_m":37431703.489572,
+    "geom:area_square_m":37431617.762121,
     "geom:bbox":"128.936172,34.882915,129.015234,35.133751",
     "geom:latitude":35.08795,
     "geom:longitude":128.976398,
@@ -132,16 +132,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289271,
+        "meso:local_id":"21100",
         "qs_pg:id":1087059,
         "wd:id":"Q50400",
         "wk:page":"Saha District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053996,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e7be549fc1896c58bc89f722101d85c",
+    "wof:geomhash":"79c626e5fd9523145e5d09021fa1b8de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890474617,
-    "wof:lastmodified":1690938357,
+    "wof:lastmodified":1695886770,
     "wof:name":"Saha",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/474/629/890474629.geojson
+++ b/data/890/474/629/890474629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047897,
-    "geom:area_square_m":482803101.511885,
+    "geom:area_square_m":482803147.487092,
     "geom:bbox":"128.094222,35.252234,128.438674,35.526958",
     "geom:latitude":35.393475,
     "geom:longitude":128.279713,
@@ -135,16 +135,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289303,
+        "meso:local_id":"38310",
         "qs_pg:id":1092358,
         "wd:id":"Q50316",
         "wk:page":"Uiryeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"556c211ef419afad3f3332b1b8b9475e",
+    "wof:geomhash":"0850e5eb176ca45bb5e9b14b8ac7819f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +156,7 @@
         }
     ],
     "wof:id":890474629,
-    "wof:lastmodified":1690938358,
+    "wof:lastmodified":1695886636,
     "wof:name":"Uiryeong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/474/631/890474631.geojson
+++ b/data/890/474/631/890474631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117029,
-    "geom:area_square_m":1165311684.647301,
+    "geom:area_square_m":1165311757.425581,
     "geom:bbox":"128.292288,36.192379,128.898243,36.532621",
     "geom:latitude":36.36222,
     "geom:longitude":128.616672,
@@ -141,16 +141,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289304,
+        "meso:local_id":"37320",
         "qs_pg:id":1092359,
         "wd:id":"Q50317",
         "wk:page":"Uiseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7dbfbb0ff23a369d69073ba7c8dac0b9",
+    "wof:geomhash":"f6f114c79d85cfbfd6866389d2083aae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890474631,
-    "wof:lastmodified":1690938363,
+    "wof:lastmodified":1695886637,
     "wof:name":"Uiseong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/633/890474633.geojson
+++ b/data/890/474/633/890474633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085053,
-    "geom:area_square_m":878759977.956208,
+    "geom:area_square_m":878759955.242003,
     "geom:bbox":"126.167985,33.112862,126.946281,33.488596",
     "geom:latitude":33.325283,
     "geom:longitude":126.581256,
@@ -178,14 +178,16 @@
     "wof:concordances":{
         "gn:id":1836630,
         "gp:id":28289284,
+        "meso:local_id":"39020",
         "qs_pg:id":25565
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b0cc18004deb9830ff3cbe1bbed3569",
+    "wof:geomhash":"95d7bde561457a0c95c88a98cd1b04c1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +197,7 @@
         }
     ],
     "wof:id":890474633,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886636,
     "wof:name":"Seogwipo",
     "wof:parent_id":85673237,
     "wof:placetype":"county",

--- a/data/890/474/635/890474635.geojson
+++ b/data/890/474/635/890474635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089468,
-    "geom:area_square_m":906273509.504944,
+    "geom:area_square_m":906273412.530625,
     "geom:bbox":"127.176895,34.831223,127.586296,35.192106",
     "geom:latitude":34.995337,
     "geom:longitude":127.389866,
@@ -160,14 +160,16 @@
     "wof:concordances":{
         "gn:id":1835646,
         "gp:id":28289295,
+        "meso:local_id":"36030",
         "qs_pg:id":25568
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7eb79c8087324ec60d238cdae2cd7d0e",
+    "wof:geomhash":"19dd000070814dd013b23a463cbffae4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +179,7 @@
         }
     ],
     "wof:id":890474635,
-    "wof:lastmodified":1619481400,
+    "wof:lastmodified":1695886636,
     "wof:name":"Suncheon",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/474/637/890474637.geojson
+++ b/data/890/474/637/890474637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005111,
-    "geom:area_square_m":50229111.420837,
+    "geom:area_square_m":50228970.194805,
     "geom:bbox":"126.931165,37.297099,127.045865,37.415195",
     "geom:latitude":37.360943,
     "geom:longitude":126.988264,
@@ -165,14 +165,16 @@
     "wof:concordances":{
         "gn:id":8393796,
         "gp:id":28289305,
+        "meso:local_id":"31170",
         "qs_pg:id":25581
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"26945db1cec107f48e1759129c1e3a5f",
+    "wof:geomhash":"cac5b20f65d430296fc7208048d49201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +184,7 @@
         }
     ],
     "wof:id":890474637,
-    "wof:lastmodified":1619481401,
+    "wof:lastmodified":1695886637,
     "wof:name":"Uiwang",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/639/890474639.geojson
+++ b/data/890/474/639/890474639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099752,
-    "geom:area_square_m":986288490.527984,
+    "geom:area_square_m":986289064.601119,
     "geom:bbox":"129.084036,36.64425,129.478729,37.149994",
     "geom:latitude":36.90645,
     "geom:longitude":129.313682,
@@ -150,16 +150,18 @@
     "wof:concordances":{
         "gn:id":1833762,
         "gp:id":28289306,
+        "meso:local_id":"37420",
         "qs_pg:id":25582,
         "wd:id":"Q50314",
         "wk:page":"Uljin County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"354f45f766fc822c58c5dc34fc0b98cf",
+    "wof:geomhash":"5e0895ff9e2306189e61835175da85c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474639,
-    "wof:lastmodified":1690938362,
+    "wof:lastmodified":1695886771,
     "wof:name":"Uljin",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/641/890474641.geojson
+++ b/data/890/474/641/890474641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056173,
-    "geom:area_square_m":554462566.923554,
+    "geom:area_square_m":554462779.282422,
     "geom:bbox":"127.108061,36.893584,127.518568,37.155062",
     "geom:latitude":37.03572,
     "geom:longitude":127.305508,
@@ -181,14 +181,16 @@
     "wof:concordances":{
         "gn:id":8393797,
         "gp:id":28289109,
+        "meso:local_id":"31220",
         "qs_pg:id":1097651
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17982e301b7ab6fb62d06e157eb84a55",
+    "wof:geomhash":"170722cca2cb782ff8c18bed65246e44",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -198,7 +200,7 @@
         }
     ],
     "wof:id":890474641,
-    "wof:lastmodified":1619481401,
+    "wof:lastmodified":1695886637,
     "wof:name":"Anseong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/474/645/890474645.geojson
+++ b/data/890/474/645/890474645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059664,
-    "geom:area_square_m":599879524.262166,
+    "geom:area_square_m":599879235.546209,
     "geom:bbox":"127.084354,35.456709,127.43583,35.771818",
     "geom:latitude":35.598222,
     "geom:longitude":127.238133,
@@ -150,16 +150,18 @@
     "wof:concordances":{
         "gn:id":1843583,
         "gp:id":28289211,
+        "meso:local_id":"35350",
         "qs_pg:id":1097656,
         "wd:id":"Q50319",
         "wk:page":"Imsil County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1caf9257b759329f1414168050ea5d21",
+    "wof:geomhash":"3e91e886b80698cf07e4bf6d2d9bdc2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474645,
-    "wof:lastmodified":1690938357,
+    "wof:lastmodified":1695886635,
     "wof:name":"Imsil",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/474/647/890474647.geojson
+++ b/data/890/474/647/890474647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004565,
-    "geom:area_square_m":44744813.739307,
+    "geom:area_square_m":44744805.510473,
     "geom:bbox":"126.684585,37.519653,126.790115,37.593726",
     "geom:latitude":37.558073,
     "geom:longitude":126.737462,
@@ -130,16 +130,18 @@
     "wof:concordances":{
         "gn:id":8417631,
         "gp:id":28289194,
+        "meso:local_id":"23070",
         "qs_pg:id":1097659,
         "wd:id":"Q27331104",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1f80ee4d25988317dc051d837256027",
+    "wof:geomhash":"6292c4431745d442707d666f2b301b3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +151,7 @@
         }
     ],
     "wof:id":890474647,
-    "wof:lastmodified":1690938361,
+    "wof:lastmodified":1695886636,
     "wof:name":"Gyeyang",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/474/649/890474649.geojson
+++ b/data/890/474/649/890474649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048312,
-    "geom:area_square_m":480645327.939048,
+    "geom:area_square_m":480645209.65562,
     "geom:bbox":"126.674007,36.314798,127.029594,36.57419",
     "geom:latitude":36.430519,
     "geom:longitude":126.854716,
@@ -170,16 +170,18 @@
     "wof:concordances":{
         "gn:id":1845490,
         "gp:id":28289135,
+        "meso:local_id":"34350",
         "qs_pg:id":30462,
         "wd:id":"Q50332",
         "wk:page":"Cheongyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469053998,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa8168a80e4c401730f137ad848e983a",
+    "wof:geomhash":"a665a6effc2e72f77333d74e9ee776e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -189,7 +191,7 @@
         }
     ],
     "wof:id":890474649,
-    "wof:lastmodified":1690938360,
+    "wof:lastmodified":1695886767,
     "wof:name":"Cheongyang",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/681/890474681.geojson
+++ b/data/890/474/681/890474681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075315,
-    "geom:area_square_m":757717699.327403,
+    "geom:area_square_m":757717848.956095,
     "geom:bbox":"128.972001,35.329582,129.369522,35.726015",
     "geom:latitude":35.547815,
     "geom:longitude":129.18703,
@@ -129,16 +129,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289307,
+        "meso:local_id":"26310",
         "qs_pg:id":32689,
         "wd:id":"Q50313",
         "wk:page":"Ulju County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054000,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2192a509b88c6bc2bc8f7150a537842f",
+    "wof:geomhash":"7e72b4d49acbd762c3c5ca363e556451",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +150,7 @@
         }
     ],
     "wof:id":890474681,
-    "wof:lastmodified":1690938356,
+    "wof:lastmodified":1695886635,
     "wof:name":"Ulju",
     "wof:parent_id":85673231,
     "wof:placetype":"county",

--- a/data/890/474/683/890474683.geojson
+++ b/data/890/474/683/890474683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08165,
-    "geom:area_square_m":817618630.699903,
+    "geom:area_square_m":817618446.911824,
     "geom:bbox":"126.995856,35.618845,127.379671,36.131341",
     "geom:latitude":35.92047,
     "geom:longitude":127.216951,
@@ -150,16 +150,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289309,
+        "meso:local_id":"35310",
         "qs_pg:id":32690,
         "wd:id":"Q50312",
         "wk:page":"Wanju County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054000,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"faeba2accb44b35c6633c21f21f7ff24",
+    "wof:geomhash":"0dbe3817b09a4ab7334f828d22b00f0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474683,
-    "wof:lastmodified":1690938362,
+    "wof:lastmodified":1695886637,
     "wof:name":"Wanju",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/474/685/890474685.geojson
+++ b/data/890/474/685/890474685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072553,
-    "geom:area_square_m":705144174.217644,
+    "geom:area_square_m":705143957.918467,
     "geom:bbox":"127.833977,37.998514,128.165871,38.336868",
     "geom:latitude":38.186679,
     "geom:longitude":127.996565,
@@ -144,16 +144,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289312,
+        "meso:local_id":"32380",
         "qs_pg:id":32691,
         "wd:id":"Q50253",
         "wk:page":"Yanggu County, Gangwon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054000,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0664b4d788f38b5efd89535c8b5f0a35",
+    "wof:geomhash":"dd926d66958229809a504317e67921c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890474685,
-    "wof:lastmodified":1690938361,
+    "wof:lastmodified":1695886636,
     "wof:name":"Yanggu",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/474/687/890474687.geojson
+++ b/data/890/474/687/890474687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050619,
-    "geom:area_square_m":513950983.318313,
+    "geom:area_square_m":513950762.557832,
     "geom:bbox":"126.362053,34.672596,126.864149,34.950879",
     "geom:latitude":34.802489,
     "geom:longitude":126.645157,
@@ -150,16 +150,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289322,
+        "meso:local_id":"36410",
         "qs_pg:id":32692,
         "wd:id":"Q50262",
         "wk:page":"Yeongam County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054000,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c03f309878938cfc5e9d5dcad0a3f19",
+    "wof:geomhash":"aa43ae1d8894432d77997e0f729c373d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890474687,
-    "wof:lastmodified":1690938358,
+    "wof:lastmodified":1695886636,
     "wof:name":"Yeongam",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/474/695/890474695.geojson
+++ b/data/890/474/695/890474695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05482,
-    "geom:area_square_m":543700046.504426,
+    "geom:area_square_m":543700315.125469,
     "geom:bbox":"126.583387,36.525514,126.971345,36.807269",
     "geom:latitude":36.670351,
     "geom:longitude":126.784276,
@@ -153,16 +153,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289336,
+        "meso:local_id":"34370",
         "qs_pg:id":1110374,
         "wd:id":"Q50307",
         "wk:page":"Yesan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054001,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef555bd034c13054fe51d2385f001193",
+    "wof:geomhash":"1983b80aacda0633c07083bbc3ba9218",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +174,7 @@
         }
     ],
     "wof:id":890474695,
-    "wof:lastmodified":1690938359,
+    "wof:lastmodified":1695886636,
     "wof:name":"Yesan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/474/963/890474963.geojson
+++ b/data/890/474/963/890474963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084661,
-    "geom:area_square_m":843059273.452202,
+    "geom:area_square_m":843058953.15792,
     "geom:bbox":"128.853365,36.161089,129.26267,36.593558",
     "geom:latitude":36.358133,
     "geom:longitude":129.058788,
@@ -141,16 +141,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289133,
+        "meso:local_id":"37330",
         "qs_pg:id":1112259,
         "wd:id":"Q50331",
         "wk:page":"Cheongsong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054012,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec2b01642d2847599090e18488ed04d2",
+    "wof:geomhash":"3b5ebe26e9b29f02ad576b26f2a7a853",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890474963,
-    "wof:lastmodified":1690938356,
+    "wof:lastmodified":1695886635,
     "wof:name":"Cheongsong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/474/965/890474965.geojson
+++ b/data/890/474/965/890474965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002102,
-    "geom:area_square_m":20618373.859534,
+    "geom:area_square_m":20618384.849299,
     "geom:bbox":"126.816655,37.472067,126.902399,37.51828",
     "geom:latitude":37.495534,
     "geom:longitude":126.855648,
@@ -151,16 +151,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289185,
+        "meso:local_id":"11170",
         "qs_pg:id":1112260,
         "wd:id":"Q50356",
         "wk:page":"Guro District, Seoul"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054012,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e953bf56d81500cdb02d74f06f364c8a",
+    "wof:geomhash":"998b0728b348f80d786276f78adcde67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890474965,
-    "wof:lastmodified":1690938355,
+    "wof:lastmodified":1695886635,
     "wof:name":"Guro",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/474/969/890474969.geojson
+++ b/data/890/474/969/890474969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061269,
-    "geom:area_square_m":611584784.70159,
+    "geom:area_square_m":611584526.156202,
     "geom:bbox":"128.412324,36.001768,128.9002,36.327529",
     "geom:latitude":36.170554,
     "geom:longitude":128.650269,
@@ -144,16 +144,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289183,
+        "meso:local_id":"37310",
         "qs_pg:id":1112261,
         "wd:id":"Q50215",
         "wk:page":"Gunwi County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054012,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c04397c2afe8c922fa69e915419ecf8b",
+    "wof:geomhash":"5f2de04bed0d80231921a9ee9bc8511f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -163,7 +165,7 @@
         }
     ],
     "wof:id":890474969,
-    "wof:lastmodified":1690938360,
+    "wof:lastmodified":1695886636,
     "wof:name":"Gunwi",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/033/890475033.geojson
+++ b/data/890/475/033/890475033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089543,
-    "geom:area_square_m":883553762.280463,
+    "geom:area_square_m":883553378.955691,
     "geom:bbox":"127.924134,36.808948,128.335667,37.261023",
     "geom:latitude":37.061021,
     "geom:longitude":128.143238,
@@ -169,14 +169,16 @@
     "wof:concordances":{
         "gn:id":1846277,
         "gp:id":28289216,
+        "meso:local_id":"33030",
         "qs_pg:id":1115383
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054016,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7ba58c7b2c741bbaa549e541ab56e1d",
+    "wof:geomhash":"68f8a98d61cefda2d7d35a5992bfc4f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +188,7 @@
         }
     ],
     "wof:id":890475033,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886628,
     "wof:name":"Jecheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/475/035/890475035.geojson
+++ b/data/890/475/035/890475035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062723,
-    "geom:area_square_m":621065754.098066,
+    "geom:area_square_m":621065515.566206,
     "geom:bbox":"126.320158,36.602859,126.656023,37.027889",
     "geom:latitude":36.796302,
     "geom:longitude":126.470371,
@@ -166,14 +166,16 @@
     "wof:concordances":{
         "gn:id":1835889,
         "gp:id":28289289,
+        "meso:local_id":"34050",
         "qs_pg:id":1115384
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054016,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52797262e9ddde67b920ab5a8ea658ff",
+    "wof:geomhash":"5242dddd1a439102e4c937302e29c0a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +185,7 @@
         }
     ],
     "wof:id":890475035,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886628,
     "wof:name":"Seosan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/475/041/890475041.geojson
+++ b/data/890/475/041/890475041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071431,
-    "geom:area_square_m":725310131.203246,
+    "geom:area_square_m":725311256.450704,
     "geom:bbox":"125.074585,34.045387,126.379585,35.212944",
     "geom:latitude":34.796558,
     "geom:longitude":126.022118,
@@ -159,16 +159,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289291,
+        "meso:local_id":"36480",
         "qs_pg:id":1115827,
         "wd:id":"Q50252",
         "wk:page":"Sinan County, South Jeolla"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054016,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3745f03742da518741bd14026680d70",
+    "wof:geomhash":"27007c1526131bf7bc934b86dd5a322b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890475041,
-    "wof:lastmodified":1690938318,
+    "wof:lastmodified":1695886626,
     "wof:name":"Sinan",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/061/890475061.geojson
+++ b/data/890/475/061/890475061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046995,
-    "geom:area_square_m":462792809.82646,
+    "geom:area_square_m":462792641.241604,
     "geom:bbox":"127.328077,37.042241,127.641564,37.36378",
     "geom:latitude":37.211708,
     "geom:longitude":127.482511,
@@ -169,14 +169,16 @@
     "wof:concordances":{
         "gn:id":8393802,
         "gp:id":28289209,
+        "meso:local_id":"31210",
         "qs_pg:id":1120181
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac4a9c3b662198f0b5fd22cdaaf2b385",
+    "wof:geomhash":"ee988dd2fbffb00178d0af95b0390820",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +188,7 @@
         }
     ],
     "wof:id":890475061,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886629,
     "wof:name":"Icheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/069/890475069.geojson
+++ b/data/890/475/069/890475069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04406,
-    "geom:area_square_m":444981400.674568,
+    "geom:area_square_m":444981438.369218,
     "geom:bbox":"127.370543,35.091322,127.628685,35.367889",
     "geom:latitude":35.237317,
     "geom:longitude":127.505123,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289186,
+        "meso:local_id":"36330",
         "qs_pg:id":1121800,
         "wd:id":"Q50214",
         "wk:page":"Gurye County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af5a93f722e1f4e19d5b4817e6b93a36",
+    "wof:geomhash":"c3bf3281e8a0481fc8d5f7cd63e62522",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890475069,
-    "wof:lastmodified":1690938325,
+    "wof:lastmodified":1695886629,
     "wof:name":"Gurye",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/073/890475073.geojson
+++ b/data/890/475/073/890475073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065957,
-    "geom:area_square_m":666934454.827244,
+    "geom:area_square_m":666934419.960858,
     "geom:bbox":"127.576244,34.923721,127.940744,35.333837",
     "geom:latitude":35.13938,
     "geom:longitude":127.781283,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289195,
+        "meso:local_id":"38360",
         "qs_pg:id":1121802,
         "wd:id":"Q26212",
         "wk:page":"Hadong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a806693193083f68363d679a3cc4d07",
+    "wof:geomhash":"16ab9e0c9243cceb29988984099e9c7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890475073,
-    "wof:lastmodified":1690938323,
+    "wof:lastmodified":1695886629,
     "wof:name":"Hadong",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/077/890475077.geojson
+++ b/data/890/475/077/890475077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086165,
-    "geom:area_square_m":877610273.121278,
+    "geom:area_square_m":877610499.880893,
     "geom:bbox":"126.237892,34.292889,126.73539,34.76289",
     "geom:latitude":34.543115,
     "geom:longitude":126.521943,
@@ -141,16 +141,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289196,
+        "meso:local_id":"36400",
         "qs_pg:id":1121803,
         "wd:id":"Q50342",
         "wk:page":"Haenam County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de99da1021c9ed936038c449f578a98a",
+    "wof:geomhash":"4b697bc1877b291f80c9e746d0d3f092",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890475077,
-    "wof:lastmodified":1690938319,
+    "wof:lastmodified":1695886627,
     "wof:name":"Haenam",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/279/890475279.geojson
+++ b/data/890/475/279/890475279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045115,
-    "geom:area_square_m":451217124.192375,
+    "geom:area_square_m":451216949.838241,
     "geom:bbox":"128.287558,35.888651,128.642097,36.122844",
     "geom:latitude":36.017134,
     "geom:longitude":128.464935,
@@ -157,16 +157,18 @@
     "wof:concordances":{
         "gn:id":1846148,
         "gp:id":28289136,
+        "meso:local_id":"37390",
         "qs_pg:id":25532,
         "wd:id":"Q50334",
         "wk:page":"Chilgok County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1b4cc7fee36a18febe1717c7da8d1c07",
+    "wof:geomhash":"9ff922aca838821a88229485c2988465",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890475279,
-    "wof:lastmodified":1690938324,
+    "wof:lastmodified":1695886767,
     "wof:name":"Chilgok",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/295/890475295.geojson
+++ b/data/890/475/295/890475295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002167,
-    "geom:area_square_m":21250585.850376,
+    "geom:area_square_m":21250508.73093,
     "geom:bbox":"126.944941,37.511852,127.018774,37.55872",
     "geom:latitude":37.534122,
     "geom:longitude":126.981133,
@@ -178,16 +178,18 @@
     "wof:concordances":{
         "gn:id":1832311,
         "gp:id":28289338,
+        "meso:local_id":"11030",
         "qs_pg:id":1151341,
         "wd:id":"Q50429",
         "wk:page":"Yongsan District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"680f89cb28caa5be8428ff39deb1e6b4",
+    "wof:geomhash":"b2fed955556cbc1017a865d7ae6b198f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +199,7 @@
         }
     ],
     "wof:id":890475295,
-    "wof:lastmodified":1690938319,
+    "wof:lastmodified":1695886627,
     "wof:name":"Yongsan",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/475/297/890475297.geojson
+++ b/data/890/475/297/890475297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001094,
-    "geom:area_square_m":10721341.392794,
+    "geom:area_square_m":10721358.850304,
     "geom:bbox":"126.968075,37.546629,127.029648,37.575676",
     "geom:latitude":37.562258,
     "geom:longitude":127.000486,
@@ -91,16 +91,18 @@
     "wof:concordances":{
         "gn:id":1845068,
         "gp:id":28289229,
+        "meso:local_id":"11020",
         "qs_pg:id":1151859,
         "wd:id":"Q6616970",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05ffd9f978a825f8e20749d287378695",
+    "wof:geomhash":"a08b5ed9b1d38f265eb91ac7f5a83cd6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +112,7 @@
         }
     ],
     "wof:id":890475297,
-    "wof:lastmodified":1627522306,
+    "wof:lastmodified":1695886770,
     "wof:name":"Jung",
     "wof:parent_id":85673185,
     "wof:placetype":"county",

--- a/data/890/475/299/890475299.geojson
+++ b/data/890/475/299/890475299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008308,
-    "geom:area_square_m":81245291.547107,
+    "geom:area_square_m":81245232.664839,
     "geom:bbox":"127.002442,37.688753,127.146873,37.782718",
     "geom:latitude":37.738008,
     "geom:longitude":127.070073,
@@ -173,14 +173,16 @@
     "wof:concordances":{
         "gn:id":8393789,
         "gp:id":28289302,
+        "meso:local_id":"31030",
         "qs_pg:id":1151881
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0431cfa298b2ea110c9c2ab45afc173",
+    "wof:geomhash":"68a82c2efec0feaea06aa672658282a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -190,7 +192,7 @@
         }
     ],
     "wof:id":890475299,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886629,
     "wof:name":"Uijeongbu",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/301/890475301.geojson
+++ b/data/890/475/301/890475301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070698,
-    "geom:area_square_m":714286980.683522,
+    "geom:area_square_m":714287254.727624,
     "geom:bbox":"127.888159,35.045652,128.370022,35.35546",
     "geom:latitude":35.206063,
     "geom:longitude":128.131723,
@@ -158,14 +158,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289224,
+        "meso:local_id":"38030",
         "qs_pg:id":1154680
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddbbd6bcdd42d2f7461ec6c3b6ecbeb2",
+    "wof:geomhash":"7defb9fb925a7c137420171961b28b6a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         }
     ],
     "wof:id":890475301,
-    "wof:lastmodified":1619481390,
+    "wof:lastmodified":1695886627,
     "wof:name":"Jinju",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/303/890475303.geojson
+++ b/data/890/475/303/890475303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045399,
-    "geom:area_square_m":458307929.028084,
+    "geom:area_square_m":458307698.627327,
     "geom:bbox":"128.695064,35.155521,129.015806,35.39749",
     "geom:latitude":35.273011,
     "geom:longitude":128.847304,
@@ -167,14 +167,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289237,
+        "meso:local_id":"38070",
         "qs_pg:id":1154681
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054027,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ead5dc4da4fa0ee1a6d520d855c9fefe",
+    "wof:geomhash":"6d344b5cfe867028b308bf99fecf2663",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890475303,
-    "wof:lastmodified":1619481391,
+    "wof:lastmodified":1695886628,
     "wof:name":"Gimhae",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/307/890475307.geojson
+++ b/data/890/475/307/890475307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075235,
-    "geom:area_square_m":747976121.206116,
+    "geom:area_square_m":747975726.83753,
     "geom:bbox":"129.149977,36.26535,129.452911,36.676474",
     "geom:latitude":36.483979,
     "geom:longitude":129.318468,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289324,
+        "meso:local_id":"37350",
         "qs_pg:id":1154683,
         "wd:id":"Q50260",
         "wk:page":"Yeongdeok County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054028,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1282cb2e60fe13c14ac701c8a797a057",
+    "wof:geomhash":"b68a31dbda540899b261657637eb09d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890475307,
-    "wof:lastmodified":1690938316,
+    "wof:lastmodified":1695886627,
     "wof:name":"Yeongdeok",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/313/890475313.geojson
+++ b/data/890/475/313/890475313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089634,
-    "geom:area_square_m":879082432.264541,
+    "geom:area_square_m":879082697.581237,
     "geom:bbox":"127.304276,37.367135,127.84976,37.671474",
     "geom:latitude":37.519012,
     "geom:longitude":127.579965,
@@ -150,16 +150,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289314,
+        "meso:local_id":"31380",
         "qs_pg:id":1154685,
         "wd:id":"Q50255",
         "wk:page":"Yangpyeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054028,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0f540729fa5a08e30d6e9ab54ab0d68c",
+    "wof:geomhash":"6bda53868e29800719971fae989b9cf0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -169,7 +171,7 @@
         }
     ],
     "wof:id":890475313,
-    "wof:lastmodified":1690938321,
+    "wof:lastmodified":1695886628,
     "wof:name":"Yangpyeong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/315/890475315.geojson
+++ b/data/890/475/315/890475315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066869,
-    "geom:area_square_m":663331405.81205,
+    "geom:area_square_m":663331474.834744,
     "geom:bbox":"128.262583,36.460237,128.611592,36.848993",
     "geom:latitude":36.654792,
     "geom:longitude":128.424467,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289317,
+        "meso:local_id":"37400",
         "qs_pg:id":1154686,
         "wd:id":"Q50308",
         "wk:page":"Yecheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054028,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b0709c52f0d8d0ee6c2dda7a275cd6f",
+    "wof:geomhash":"85baa5ea9d1d89f573b8180bb7717893",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890475315,
-    "wof:lastmodified":1690938320,
+    "wof:lastmodified":1695886628,
     "wof:name":"Yecheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/319/890475319.geojson
+++ b/data/890/475/319/890475319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091513,
-    "geom:area_square_m":915270059.79022,
+    "geom:area_square_m":915270185.134785,
     "geom:bbox":"128.698271,35.831738,129.155333,36.185274",
     "geom:latitude":36.01641,
     "geom:longitude":128.944141,
@@ -149,14 +149,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289323,
+        "meso:local_id":"37070",
         "qs_pg:id":1154688
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054028,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee737c35137e62d10fa8d207b099bdcd",
+    "wof:geomhash":"829479dd207cb793ff63b38b73866a17",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890475319,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886629,
     "wof:name":"Yeongcheon",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/321/890475321.geojson
+++ b/data/890/475/321/890475321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001313,
-    "geom:area_square_m":13285895.683813,
+    "geom:area_square_m":13285896.440177,
     "geom:bbox":"129.032663,35.037083,129.097076,35.101223",
     "geom:latitude":35.078416,
     "geom:longitude":129.065788,
@@ -136,16 +136,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289326,
+        "meso:local_id":"21040",
         "qs_pg:id":1154689,
         "wd:id":"Q50423",
         "wk:page":"Yeongdo District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054028,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"969290db49d17b9e7b3ad4830e4dad15",
+    "wof:geomhash":"552bb73dbb48f66cb7546f60b8b75d9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -155,7 +157,7 @@
         }
     ],
     "wof:id":890475321,
-    "wof:lastmodified":1690938326,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yeongdo",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/475/357/890475357.geojson
+++ b/data/890/475/357/890475357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007789,
-    "geom:area_square_m":76417260.943341,
+    "geom:area_square_m":76417316.710547,
     "geom:bbox":"130.800385,37.447918,130.950394,37.546223",
     "geom:latitude":37.497194,
     "geom:longitude":130.871524,
@@ -159,16 +159,18 @@
     "wof:concordances":{
         "gn:id":1833753,
         "gp:id":28289340,
+        "meso:local_id":"37430",
         "qs_pg:id":1184292,
         "wd:id":"Q485570",
         "wk:page":"Ulleung County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054031,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9802cdcd1be41015d2f4796f1896858b",
+    "wof:geomhash":"759869f4feee6cbb0cc4989ddcb7c477",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890475357,
-    "wof:lastmodified":1690938322,
+    "wof:lastmodified":1695886771,
     "wof:name":"Ulleung",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/391/890475391.geojson
+++ b/data/890/475/391/890475391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054074,
-    "geom:area_square_m":546257245.038374,
+    "geom:area_square_m":546257108.517413,
     "geom:bbox":"127.084198,35.07,127.418987,35.337692",
     "geom:latitude":35.217426,
     "geom:longitude":127.264793,
@@ -132,16 +132,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289174,
+        "meso:local_id":"36320",
         "qs_pg:id":965383,
         "wd:id":"Q50212",
         "wk:page":"Gokseong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054032,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"87f9b66033fe9fab367146f82418f609",
+    "wof:geomhash":"8668504255c7b7163c043bad276fc419",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +153,7 @@
         }
     ],
     "wof:id":890475391,
-    "wof:lastmodified":1690938317,
+    "wof:lastmodified":1695886627,
     "wof:name":"Gokseong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/475/397/890475397.geojson
+++ b/data/890/475/397/890475397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034391,
-    "geom:area_square_m":344223503.867598,
+    "geom:area_square_m":344223402.389301,
     "geom:bbox":"125.955391,35.72789,126.917932,36.259556",
     "geom:latitude":35.95743,
     "geom:longitude":126.716011,
@@ -148,15 +148,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289182,
+        "meso:local_id":"35020",
         "qs_pg:id":407611,
         "wd:id":"Q50246"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054032,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bf070f1e4e07fe506917d78f5dbc519",
+    "wof:geomhash":"7aaed115a2ee3c38c7748a2e60c4c0eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890475397,
-    "wof:lastmodified":1690938317,
+    "wof:lastmodified":1695886736,
     "wof:name":"Gunsan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/429/890475429.geojson
+++ b/data/890/475/429/890475429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031307,
-    "geom:area_square_m":305851778.131888,
+    "geom:area_square_m":305852086.995529,
     "geom:bbox":"126.905891,37.668876,127.126349,37.942931",
     "geom:latitude":37.808185,
     "geom:longitude":127.002849,
@@ -165,14 +165,16 @@
     "wof:concordances":{
         "gn:id":8393804,
         "gp:id":28289313,
+        "meso:local_id":"31260",
         "qs_pg:id":25583
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054033,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c151680357fc3b1f4d907cbca660115",
+    "wof:geomhash":"f9a07f7d05501a4f97760ae20d5946ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +184,7 @@
         }
     ],
     "wof:id":890475429,
-    "wof:lastmodified":1619481392,
+    "wof:lastmodified":1695886629,
     "wof:name":"Yangju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/475/465/890475465.geojson
+++ b/data/890/475/465/890475465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07037,
-    "geom:area_square_m":682120021.30389,
+    "geom:area_square_m":682119390.815051,
     "geom:bbox":"128.217401,38.189076,128.587493,38.618412",
     "geom:latitude":38.3787,
     "geom:longitude":128.398651,
@@ -160,16 +160,18 @@
     "wof:concordances":{
         "gn:id":1842515,
         "gp:id":28289177,
+        "meso:local_id":"32400",
         "qs_pg:id":335697,
         "wd:id":"Q50209",
         "wk:page":"Goseong County, Gangwon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054035,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0db7b09bdff92587ac6aea80c1920f6",
+    "wof:geomhash":"e769e2eba69af479b3d8f947961c4150",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
         }
     ],
     "wof:id":890475465,
-    "wof:lastmodified":1690938319,
+    "wof:lastmodified":1695886768,
     "wof:name":"Goseong",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/467/890475467.geojson
+++ b/data/890/475/467/890475467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036734,
-    "geom:area_square_m":372898707.551585,
+    "geom:area_square_m":372898604.912653,
     "geom:bbox":"127.807053,34.678749,128.088745,34.94622",
     "geom:latitude":34.817954,
     "geom:longitude":127.943206,
@@ -154,16 +154,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289257,
+        "meso:local_id":"38350",
         "qs_pg:id":362852,
         "wd:id":"Q26123",
         "wk:page":"Namhae County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054035,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7da75764c2e8b3eb94be58ff537699c",
+    "wof:geomhash":"b23a7c58fec853fdf75fa2f452e25d0b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
         }
     ],
     "wof:id":890475467,
-    "wof:lastmodified":1690938324,
+    "wof:lastmodified":1695886629,
     "wof:name":"Namhae",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/475/485/890475485.geojson
+++ b/data/890/475/485/890475485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059458,
-    "geom:area_square_m":598924126.301973,
+    "geom:area_square_m":598923703.398816,
     "geom:bbox":"126.425392,35.302468,126.774447,35.576987",
     "geom:latitude":35.448705,
     "geom:longitude":126.616946,
@@ -147,16 +147,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289171,
+        "meso:local_id":"35370",
         "qs_pg:id":400704,
         "wd:id":"Q50210",
         "wk:page":"Gochang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054036,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f18fce633299f29dfe30d302704c45b",
+    "wof:geomhash":"0edd104e4792acbc1c296e88a505012a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890475485,
-    "wof:lastmodified":1690938318,
+    "wof:lastmodified":1695886627,
     "wof:name":"Gochang",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/539/890475539.geojson
+++ b/data/890/475/539/890475539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053504,
-    "geom:area_square_m":529719716.490718,
+    "geom:area_square_m":529720039.2265,
     "geom:bbox":"126.830634,36.64872,127.124731,36.94545",
     "geom:latitude":36.805415,
     "geom:longitude":126.984636,
@@ -189,14 +189,16 @@
     "wof:concordances":{
         "gn:id":1846848,
         "gp:id":28289111,
+        "meso:local_id":"34040",
         "qs_pg:id":25521
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054040,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ae06ed6f654bc63a300a8c0e04a0e46",
+    "wof:geomhash":"e88076a0ef6586b4f07c2e6038adfb37",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +208,7 @@
         }
     ],
     "wof:id":890475539,
-    "wof:lastmodified":1619481391,
+    "wof:lastmodified":1695886628,
     "wof:name":"Asan",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/475/545/890475545.geojson
+++ b/data/890/475/545/890475545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054579,
-    "geom:area_square_m":543755266.059396,
+    "geom:area_square_m":543755102.300539,
     "geom:bbox":"127.488181,36.171605,127.892478,36.445948",
     "geom:latitude":36.321777,
     "geom:longitude":127.658339,
@@ -163,16 +163,18 @@
     "wof:concordances":{
         "gn:id":1839869,
         "gp:id":28289262,
+        "meso:local_id":"33330",
         "qs_pg:id":48312,
         "wd:id":"Q50309",
         "wk:page":"Okcheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054040,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3218ab3f30e1b5b268637ef6c81678e",
+    "wof:geomhash":"a0962397b740a1f2c31c8c6704684889",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +184,7 @@
         }
     ],
     "wof:id":890475545,
-    "wof:lastmodified":1690938321,
+    "wof:lastmodified":1695886628,
     "wof:name":"Okcheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/475/719/890475719.geojson
+++ b/data/890/475/719/890475719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052789,
-    "geom:area_square_m":530357261.825448,
+    "geom:area_square_m":530356887.664412,
     "geom:bbox":"127.361373,35.468064,127.698335,35.838317",
     "geom:latitude":35.658422,
     "geom:longitude":127.545683,
@@ -147,16 +147,18 @@
     "wof:concordances":{
         "gn:id":1846351,
         "gp:id":28289215,
+        "meso:local_id":"35340",
         "qs_pg:id":772244,
         "wd:id":"Q50321",
         "wk:page":"Jangsu County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054047,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e474fa2a428d03586ea0d91d9d3ad82e",
+    "wof:geomhash":"24a9be13415aac1aa32ccc09c19cff8f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890475719,
-    "wof:lastmodified":1690938326,
+    "wof:lastmodified":1695886629,
     "wof:name":"Jangsu",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/757/890475757.geojson
+++ b/data/890/475/757/890475757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069364,
-    "geom:area_square_m":696748749.868955,
+    "geom:area_square_m":696748599.012819,
     "geom:bbox":"128.526078,35.5661,129.049589,35.844806",
     "geom:latitude":35.673867,
     "geom:longitude":128.785788,
@@ -154,16 +154,18 @@
     "wof:concordances":{
         "gn:id":1845685,
         "gp:id":28289131,
+        "meso:local_id":"37360",
         "qs_pg:id":335700,
         "wd:id":"Q50330",
         "wk:page":"Cheongdo County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054048,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"688c42304285f2e113fc6ae77cb57a6c",
+    "wof:geomhash":"32ff179916445e39f932c96ca2be205e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
         }
     ],
     "wof:id":890475757,
-    "wof:lastmodified":1690938322,
+    "wof:lastmodified":1695886767,
     "wof:name":"Cheongdo",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/475/779/890475779.geojson
+++ b/data/890/475/779/890475779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002847,
-    "geom:area_square_m":28778828.843171,
+    "geom:area_square_m":28778636.535817,
     "geom:bbox":"129.010725,35.134927,129.085687,35.203312",
     "geom:latitude":35.166242,
     "geom:longitude":129.046246,
@@ -141,16 +141,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289124,
+        "meso:local_id":"21050",
         "qs_pg:id":1209104,
         "wd:id":"Q50390",
         "wk:page":"Busanjin District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054050,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c20b572f99581e49fa0446bfdfa93a5",
+    "wof:geomhash":"5754e7153630bbbc7e2299a645551908",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890475779,
-    "wof:lastmodified":1690938321,
+    "wof:lastmodified":1695886766,
     "wof:name":"Busanjin",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/475/783/890475783.geojson
+++ b/data/890/475/783/890475783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04423,
-    "geom:area_square_m":444304623.6696,
+    "geom:area_square_m":444305220.512278,
     "geom:bbox":"126.07122,35.565007,126.83996,35.889584",
     "geom:latitude":35.669364,
     "geom:longitude":126.635784,
@@ -142,16 +142,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289116,
+        "meso:local_id":"35380",
         "qs_pg:id":1264390,
         "wd:id":"Q50246",
         "wk:page":"Buan County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054050,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"00e87cc48cdb9099264cc353aba8bc7c",
+    "wof:geomhash":"d134dd0a5a2a5ff13576fdc2f5bfc93c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +163,7 @@
         }
     ],
     "wof:id":890475783,
-    "wof:lastmodified":1690938320,
+    "wof:lastmodified":1695886628,
     "wof:name":"Buan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/797/890475797.geojson
+++ b/data/890/475/797/890475797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074232,
-    "geom:area_square_m":747988223.359599,
+    "geom:area_square_m":747988699.755395,
     "geom:bbox":"127.17936,35.303124,127.671889,35.561526",
     "geom:latitude":35.422796,
     "geom:longitude":127.442363,
@@ -160,14 +160,16 @@
     "wof:concordances":{
         "gn:id":1840378,
         "gp:id":28289258,
+        "meso:local_id":"35050",
         "qs_pg:id":1285250
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054050,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0fa2fe41279b5fde5ddda3646f6ba4e5",
+    "wof:geomhash":"c90898dbda1bf0a61be882beab4811ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +179,7 @@
         }
     ],
     "wof:id":890475797,
-    "wof:lastmodified":1619481390,
+    "wof:lastmodified":1695886627,
     "wof:name":"Namwon",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/951/890475951.geojson
+++ b/data/890/475/951/890475951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069768,
-    "geom:area_square_m":701420612.2595,
+    "geom:area_square_m":701420603.074841,
     "geom:bbox":"126.715515,35.461737,127.113056,35.760882",
     "geom:latitude":35.603783,
     "geom:longitude":126.906082,
@@ -155,14 +155,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289217,
+        "meso:local_id":"35040",
         "qs_pg:id":891198
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054056,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3698a014b189b8c8501e0105d79a45f0",
+    "wof:geomhash":"a1a0ba4f6e93c2a2927669abde55e832",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -172,7 +174,7 @@
         }
     ],
     "wof:id":890475951,
-    "wof:lastmodified":1619481391,
+    "wof:lastmodified":1695886628,
     "wof:name":"Jeongeup",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/475/955/890475955.geojson
+++ b/data/890/475/955/890475955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185259,
-    "geom:area_square_m":1811385824.943541,
+    "geom:area_square_m":1811386018.589213,
     "geom:bbox":"127.537893,37.553074,128.591684,37.948458",
     "geom:latitude":37.745745,
     "geom:longitude":128.075996,
@@ -143,15 +143,17 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289204,
+        "meso:local_id":"32310",
         "qs_pg:id":362817,
         "wd:id":"Q50344"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054056,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8cf5e5d21912a3500ba7c2bb3a3ee7d",
+    "wof:geomhash":"57471668eddc724a2c1eb313b6eccf3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +163,7 @@
         }
     ],
     "wof:id":890475955,
-    "wof:lastmodified":1690938318,
+    "wof:lastmodified":1695886627,
     "wof:name":"Hongcheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/961/890475961.geojson
+++ b/data/890/475/961/890475961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041399,
-    "geom:area_square_m":415392170.193014,
+    "geom:area_square_m":415392149.032241,
     "geom:bbox":"128.350812,35.614253,128.69724,35.944176",
     "geom:latitude":35.761274,
     "geom:longitude":128.499671,
@@ -94,16 +94,18 @@
     "wof:concordances":{
         "gn:id":1834970,
         "gp:id":28289141,
+        "meso:local_id":"22310",
         "qs_pg:id":392697,
         "wd:id":"Q6616966",
         "wk:page":"List of districts and county of Daegu"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054056,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21fb266aafff6418b367ab9a7615f269",
+    "wof:geomhash":"c991aa9859d58a6e04e3a21a24d1bce1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +115,7 @@
         }
     ],
     "wof:id":890475961,
-    "wof:lastmodified":1690938321,
+    "wof:lastmodified":1695886767,
     "wof:name":"Dalseong",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/475/963/890475963.geojson
+++ b/data/890/475/963/890475963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065183,
-    "geom:area_square_m":635087197.915057,
+    "geom:area_square_m":635087456.732104,
     "geom:bbox":"128.405685,37.861997,128.810445,38.167337",
     "geom:latitude":38.005493,
     "geom:longitude":128.596573,
@@ -162,16 +162,18 @@
     "wof:concordances":{
         "gn:id":1832808,
         "gp:id":28289316,
+        "meso:local_id":"32410",
         "qs_pg:id":392722,
         "wd:id":"Q50254",
         "wk:page":"Yangyang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054056,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46f76ef265bc488d3df08e8ba78dd2ea",
+    "wof:geomhash":"36a0c1bc4e6001d5aed86ea823bcce31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -181,7 +183,7 @@
         }
     ],
     "wof:id":890475963,
-    "wof:lastmodified":1690938317,
+    "wof:lastmodified":1695886771,
     "wof:name":"Yangyang",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/475/965/890475965.geojson
+++ b/data/890/475/965/890475965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069658,
-    "geom:area_square_m":677837069.743941,
+    "geom:area_square_m":677836903.649061,
     "geom:bbox":"126.797427,37.92864,127.193712,38.295181",
     "geom:latitude":38.097477,
     "geom:longitude":127.028957,
@@ -158,16 +158,18 @@
     "wof:concordances":{
         "gn:id":8393736,
         "gp:id":28289321,
+        "meso:local_id":"31350",
         "qs_pg:id":392723,
         "wd:id":"Q50258",
         "wk:page":"Yeoncheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054056,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c72e576406d1839af9a32c34344c137d",
+    "wof:geomhash":"2d1cb14d6e4e8b7c2bd43eb83a8a773a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +179,7 @@
         }
     ],
     "wof:id":890475965,
-    "wof:lastmodified":1690938317,
+    "wof:lastmodified":1695886627,
     "wof:name":"Yeoncheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/019/890476019.geojson
+++ b/data/890/476/019/890476019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079984,
-    "geom:area_square_m":802837548.112038,
+    "geom:area_square_m":802837375.768783,
     "geom:bbox":"127.679451,35.512554,128.095737,35.910758",
     "geom:latitude":35.732621,
     "geom:longitude":127.90519,
@@ -151,16 +151,18 @@
     "wof:concordances":{
         "gn:id":1842853,
         "gp:id":28289233,
+        "meso:local_id":"38390",
         "qs_pg:id":772246,
         "wd:id":"Q50206",
         "wk:page":"Geochang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054058,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"197f4f4c83dfd573c25d7a6ebcbf8d4e",
+    "wof:geomhash":"0514d38b73776ef115c72c5781479644",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
         }
     ],
     "wof:id":890476019,
-    "wof:lastmodified":1690938313,
+    "wof:lastmodified":1695886768,
     "wof:name":"Geochang",
     "wof:parent_id":85673215,
     "wof:placetype":"county",

--- a/data/890/476/025/890476025.geojson
+++ b/data/890/476/025/890476025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006473,
-    "geom:area_square_m":64895816.33952,
+    "geom:area_square_m":64895785.99508,
     "geom:bbox":"128.469125,35.771959,128.588563,35.871327",
     "geom:latitude":35.828136,
     "geom:longitude":128.53045,
@@ -134,16 +134,18 @@
     "wof:concordances":{
         "gn:id":8419824,
         "gp:id":28289140,
+        "meso:local_id":"22070",
         "qs_pg:id":206548,
         "wd:id":"Q50370",
         "wk:page":"Dalseo District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d996a5c84238985a1c1187b130e424f5",
+    "wof:geomhash":"6342f36f68732eddf9b36ae130ef03cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +155,7 @@
         }
     ],
     "wof:id":890476025,
-    "wof:lastmodified":1690938312,
+    "wof:lastmodified":1695886767,
     "wof:name":"Dalseo",
     "wof:parent_id":85673213,
     "wof:placetype":"county",

--- a/data/890/476/035/890476035.geojson
+++ b/data/890/476/035/890476035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00159,
-    "geom:area_square_m":15613551.531529,
+    "geom:area_square_m":15613456.431973,
     "geom:bbox":"126.636793,37.38345,126.710472,37.439483",
     "geom:latitude":37.419902,
     "geom:longitude":126.671029,
@@ -90,16 +90,18 @@
     "wof:concordances":{
         "gn:id":8417654,
         "gp:id":28289334,
+        "meso:local_id":"23040",
         "qs_pg:id":206568,
         "wd:id":"Q6616970",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"224f7aca6737c8ba17c3ce7126a0159c",
+    "wof:geomhash":"62e1207edc870253d91709aae7a5f45e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +111,7 @@
         }
     ],
     "wof:id":890476035,
-    "wof:lastmodified":1627522308,
+    "wof:lastmodified":1695886772,
     "wof:name":"Yeonsu",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/037/890476037.geojson
+++ b/data/890/476/037/890476037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00328,
-    "geom:area_square_m":32179296.371315,
+    "geom:area_square_m":32179380.413271,
     "geom:bbox":"126.679927,37.466271,126.76737,37.53219",
     "geom:latitude":37.498518,
     "geom:longitude":126.721991,
@@ -90,16 +90,18 @@
     "wof:concordances":{
         "gn:id":8417647,
         "gp:id":28808957,
+        "meso:local_id":"23060",
         "qs_pg:id":207064,
         "wd:id":"Q6616970",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"717435fa9dafd1a08a72bf08bdcd26d9",
+    "wof:geomhash":"e36534826846d692828feac815717b13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +111,7 @@
         }
     ],
     "wof:id":890476037,
-    "wof:lastmodified":1627522302,
+    "wof:lastmodified":1695886766,
     "wof:name":"Bupyeong",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/039/890476039.geojson
+++ b/data/890/476/039/890476039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003637,
-    "geom:area_square_m":36766313.171996,
+    "geom:area_square_m":36766145.848068,
     "geom:bbox":"128.96089,35.115426,129.025155,35.197208",
     "geom:latitude":35.159904,
     "geom:longitude":128.989419,
@@ -133,16 +133,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8462803,
+        "meso:local_id":"21150",
         "qs_pg:id":209104,
         "wd:id":"Q50398",
         "wk:page":"Sasang District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd4cbfe934e97a9d66bdec90fac92da1",
+    "wof:geomhash":"566f9d236b041024201f24814e746408",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +154,7 @@
         }
     ],
     "wof:id":890476039,
-    "wof:lastmodified":1690938312,
+    "wof:lastmodified":1695886625,
     "wof:name":"Sasang",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/476/049/890476049.geojson
+++ b/data/890/476/049/890476049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069894,
-    "geom:area_square_m":688714237.309765,
+    "geom:area_square_m":688714129.022319,
     "geom:bbox":"126.534554,37.013668,127.165084,37.294194",
     "geom:latitude":37.165792,
     "geom:longitude":126.876686,
@@ -106,14 +106,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289207,
+        "meso:local_id":"31240",
         "qs_pg:id":209439
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ee8ec6833872c1dec49e1238531408d",
+    "wof:geomhash":"3cdfc1f5f0fdc5ea0f16f76c1d75cf21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +125,7 @@
         }
     ],
     "wof:id":890476049,
-    "wof:lastmodified":1627522305,
+    "wof:lastmodified":1695886769,
     "wof:name":"Hwaseong",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/051/890476051.geojson
+++ b/data/890/476/051/890476051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067839,
-    "geom:area_square_m":662299008.559876,
+    "geom:area_square_m":662299499.713004,
     "geom:bbox":"126.668953,37.690259,127.0168,38.00751",
     "geom:latitude":37.857674,
     "geom:longitude":126.817334,
@@ -183,14 +183,16 @@
     "wof:concordances":{
         "gn:id":1839430,
         "gp:id":28289265,
+        "meso:local_id":"31200",
         "qs_pg:id":894487
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81f6f87959911fc9cba3a63c3037e9f6",
+    "wof:geomhash":"48c5bd211067b5569a54217a862f3f2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +202,7 @@
         }
     ],
     "wof:id":890476051,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886625,
     "wof:name":"Paju",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/053/890476053.geojson
+++ b/data/890/476/053/890476053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084282,
-    "geom:area_square_m":821554620.003597,
+    "geom:area_square_m":821554565.872836,
     "geom:bbox":"127.091291,37.750672,127.457549,38.184673",
     "geom:latitude":37.971342,
     "geom:longitude":127.252537,
@@ -159,14 +159,16 @@
     "wof:concordances":{
         "gn:id":1839102,
         "gp:id":28289266,
+        "meso:local_id":"31270",
         "qs_pg:id":894488
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80a8a9fd1e9ca4c9d162fdec1d4c78c6",
+    "wof:geomhash":"a81ba760e45c77e2448844c6ff00ee3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +178,7 @@
         }
     ],
     "wof:id":890476053,
-    "wof:lastmodified":1619481388,
+    "wof:lastmodified":1695886625,
     "wof:name":"Pocheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/055/890476055.geojson
+++ b/data/890/476/055/890476055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011063,
-    "geom:area_square_m":107536794.575387,
+    "geom:area_square_m":107536860.595452,
     "geom:bbox":"128.421381,38.119515,128.618088,38.231278",
     "geom:latitude":38.177374,
     "geom:longitude":128.52236,
@@ -161,14 +161,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289292,
+        "meso:local_id":"32060",
         "qs_pg:id":899975
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f8a726b03b5978ce8e42d48679c6f95",
+    "wof:geomhash":"3c1fd416272446bb932fa4ac1a69aa62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +180,7 @@
         }
     ],
     "wof:id":890476055,
-    "wof:lastmodified":1636497472,
+    "wof:lastmodified":1695886737,
     "wof:name":"Sokcho",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/057/890476057.geojson
+++ b/data/890/476/057/890476057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05048,
-    "geom:area_square_m":504837805.380317,
+    "geom:area_square_m":504837785.251651,
     "geom:bbox":"126.855523,35.886134,127.139513,36.159616",
     "geom:latitude":36.023151,
     "geom:longitude":126.991846,
@@ -186,14 +186,16 @@
     "wof:concordances":{
         "gn:id":1843663,
         "gp:id":28289210,
+        "meso:local_id":"35030",
         "qs_pg:id":900304
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c84025af2ca4413d8937fddb84c58473",
+    "wof:geomhash":"dab7f9f5afa626bf1fc118985067fdc2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +205,7 @@
         }
     ],
     "wof:id":890476057,
-    "wof:lastmodified":1636497472,
+    "wof:lastmodified":1695886737,
     "wof:name":"Iksan",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/476/059/890476059.geojson
+++ b/data/890/476/059/890476059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14917,
-    "geom:area_square_m":1462217162.709729,
+    "geom:area_square_m":1462216756.031221,
     "geom:bbox":"128.243168,37.272877,128.767289,37.820709",
     "geom:latitude":37.557962,
     "geom:longitude":128.484323,
@@ -300,16 +300,18 @@
     "wof:concordances":{
         "gn:id":1838467,
         "gp:id":28289268,
+        "meso:local_id":"32340",
         "qs_pg:id":900305,
         "wd:id":"Q188624",
         "wk:page":"Pyeongchang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e0ed34636664e5174c79dc632c7e127",
+    "wof:geomhash":"ade12ba6c36460196aac291d833f7e4a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
         }
     ],
     "wof:id":890476059,
-    "wof:lastmodified":1690938315,
+    "wof:lastmodified":1695886770,
     "wof:name":"Pyeongchang",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/061/890476061.geojson
+++ b/data/890/476/061/890476061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044388,
-    "geom:area_square_m":438231712.835142,
+    "geom:area_square_m":438231602.833001,
     "geom:bbox":"126.788719,36.912056,127.155051,37.14754",
     "geom:latitude":37.019134,
     "geom:longitude":126.999662,
@@ -178,14 +178,16 @@
     "wof:concordances":{
         "gn:id":1838341,
         "gp:id":28289269,
+        "meso:local_id":"31070",
         "qs_pg:id":900306
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054061,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b38469575f05d01a35dfdf4bfec7bdd2",
+    "wof:geomhash":"7dbb68a6efb77c62030ad8277356bdf2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +197,7 @@
         }
     ],
     "wof:id":890476061,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886625,
     "wof:name":"Pyeongtaek",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/169/890476169.geojson
+++ b/data/890/476/169/890476169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10588,
-    "geom:area_square_m":1035762901.388603,
+    "geom:area_square_m":1035762879.26026,
     "geom:bbox":"128.579349,37.503873,129.072915,37.917422",
     "geom:latitude":37.708805,
     "geom:longitude":128.833569,
@@ -197,14 +197,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289164,
+        "meso:local_id":"32030",
         "qs_pg:id":216009
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"525f08620032798c783d49128cc18d5c",
+    "wof:geomhash":"952d0b7439c7235d08a00318487c1b72",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -214,7 +216,7 @@
         }
     ],
     "wof:id":890476169,
-    "wof:lastmodified":1636497472,
+    "wof:lastmodified":1695886737,
     "wof:name":"Gangneung",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/175/890476175.geojson
+++ b/data/890/476/175/890476175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04927,
-    "geom:area_square_m":496393378.545715,
+    "geom:area_square_m":496393118.311099,
     "geom:bbox":"126.861575,35.296734,127.314918,35.556015",
     "geom:latitude":35.433844,
     "geom:longitude":127.092105,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289294,
+        "meso:local_id":"35360",
         "qs_pg:id":216011,
         "wd:id":"Q50251",
         "wk:page":"Sunchang County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b17e46d7990cdda2228c99b0159636fd",
+    "wof:geomhash":"3fbd8db3cc591cf76fa92800b02fb13c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890476175,
-    "wof:lastmodified":1690938312,
+    "wof:lastmodified":1695886625,
     "wof:name":"Sunchang",
     "wof:parent_id":85673195,
     "wof:placetype":"county",

--- a/data/890/476/179/890476179.geojson
+++ b/data/890/476/179/890476179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001039,
-    "geom:area_square_m":10506636.940246,
+    "geom:area_square_m":10506560.55941,
     "geom:bbox":"129.093524,35.139256,129.134552,35.185035",
     "geom:latitude":35.163431,
     "geom:longitude":129.112658,
@@ -135,16 +135,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289298,
+        "meso:local_id":"21140",
         "qs_pg:id":216013,
         "wd:id":"Q50417",
         "wk:page":"Suyeong District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b48df541b0814b0580bec5754a256663",
+    "wof:geomhash":"9b6accd3b821e5177f2a5832cceb333c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +156,7 @@
         }
     ],
     "wof:id":890476179,
-    "wof:lastmodified":1690938316,
+    "wof:lastmodified":1695886771,
     "wof:name":"Suyeong",
     "wof:parent_id":85673227,
     "wof:placetype":"county",

--- a/data/890/476/183/890476183.geojson
+++ b/data/890/476/183/890476183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067966,
-    "geom:area_square_m":672319883.490801,
+    "geom:area_square_m":672319730.455747,
     "geom:bbox":"128.426809,36.696935,128.745443,37.070625",
     "geom:latitude":36.871257,
     "geom:longitude":128.598655,
@@ -163,14 +163,16 @@
     "wof:concordances":{
         "gn:id":1844834,
         "gp:id":28289328,
+        "meso:local_id":"37060",
         "qs_pg:id":217550
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c023abaf6f686ab0ea2e7b3ef6e9f8ae",
+    "wof:geomhash":"ba9bcab7d3dbebaf3962007de94ec611",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
         }
     ],
     "wof:id":890476183,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886626,
     "wof:name":"Yeongju",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/185/890476185.geojson
+++ b/data/890/476/185/890476185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041114,
-    "geom:area_square_m":406693130.656821,
+    "geom:area_square_m":406693403.484283,
     "geom:bbox":"127.292629,36.749935,127.585472,37.011336",
     "geom:latitude":36.871926,
     "geom:longitude":127.44188,
@@ -147,16 +147,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289221,
+        "meso:local_id":"33350",
         "qs_pg:id":220114,
         "wd:id":"Q50327",
         "wk:page":"Jincheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"154e540a8a8df7afeaa23a04d6d945db",
+    "wof:geomhash":"ce042d252e13b856360da511301640da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890476185,
-    "wof:lastmodified":1690938316,
+    "wof:lastmodified":1695886626,
     "wof:name":"Jincheon",
     "wof:parent_id":85673173,
     "wof:placetype":"county",

--- a/data/890/476/187/890476187.geojson
+++ b/data/890/476/187/890476187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105806,
-    "geom:area_square_m":1028725239.295132,
+    "geom:area_square_m":1028725031.712909,
     "geom:bbox":"127.432307,37.994268,127.914327,38.34919",
     "geom:latitude":38.159211,
     "geom:longitude":127.688418,
@@ -165,16 +165,18 @@
     "wof:concordances":{
         "gn:id":8393538,
         "gp:id":28289206,
+        "meso:local_id":"32370",
         "qs_pg:id":221226,
         "wd:id":"Q50346",
         "wk:page":"Hwacheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a363459c6a03c8ce0474c505960aba2",
+    "wof:geomhash":"40ee07903573db20be504d4d32abb64b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -184,7 +186,7 @@
         }
     ],
     "wof:id":890476187,
-    "wof:lastmodified":1690938312,
+    "wof:lastmodified":1695886769,
     "wof:name":"Hwacheon",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/189/890476189.geojson
+++ b/data/890/476/189/890476189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120545,
-    "geom:area_square_m":1186046964.918852,
+    "geom:area_square_m":1186047077.259943,
     "geom:bbox":"128.846646,37.040559,129.365769,37.480023",
     "geom:latitude":37.278069,
     "geom:longitude":129.12361,
@@ -158,14 +158,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289272,
+        "meso:local_id":"32070",
         "qs_pg:id":221248
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05dde424db577f4af2a79f728dcb00d7",
+    "wof:geomhash":"8c6f19653a9ad7ec8b9140a77fb51b77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
         }
     ],
     "wof:id":890476189,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886626,
     "wof:name":"Samcheok",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/195/890476195.geojson
+++ b/data/890/476/195/890476195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036078,
-    "geom:area_square_m":360419854.515802,
+    "geom:area_square_m":360419716.131211,
     "geom:bbox":"126.483719,35.989582,126.865707,36.191059",
     "geom:latitude":36.106888,
     "geom:longitude":126.7054,
@@ -147,16 +147,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289281,
+        "meso:local_id":"34340",
         "qs_pg:id":221250,
         "wd:id":"Q50249",
         "wk:page":"Seocheon County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"259ef2fa5c34b5b7a0e6e1151e76bfdd",
+    "wof:geomhash":"687c34aad2b718dc6533c6c8a18b4978",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890476195,
-    "wof:lastmodified":1690938311,
+    "wof:lastmodified":1695886625,
     "wof:name":"Seocheon",
     "wof:parent_id":85673203,
     "wof:placetype":"county",

--- a/data/890/476/201/890476201.geojson
+++ b/data/890/476/201/890476201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092329,
-    "geom:area_square_m":915463620.654646,
+    "geom:area_square_m":915463227.722864,
     "geom:bbox":"127.889839,36.515261,128.370663,36.872173",
     "geom:latitude":36.691117,
     "geom:longitude":128.15044,
@@ -143,14 +143,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289248,
+        "meso:local_id":"37090",
         "qs_pg:id":224875
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"62f561340cd0efbf22fed7d64cef4ac1",
+    "wof:geomhash":"50aee5441e882fb89e0b599ededa983f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890476201,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886626,
     "wof:name":"Mungyeong",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/211/890476211.geojson
+++ b/data/890/476/211/890476211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040798,
-    "geom:area_square_m":408986629.964755,
+    "geom:area_square_m":408986724.058058,
     "geom:bbox":"128.681989,35.695767,128.96625,35.994183",
     "geom:latitude":35.834214,
     "geom:longitude":128.81057,
@@ -149,14 +149,16 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289241,
+        "meso:local_id":"37100",
         "qs_pg:id":225692
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054066,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6e147d50f03efe95865b1209081f56c",
+    "wof:geomhash":"068b621ed2b3ce7c374cd4e4a909c652",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
         }
     ],
     "wof:id":890476211,
-    "wof:lastmodified":1619481388,
+    "wof:lastmodified":1695886625,
     "wof:name":"Gyeongsan",
     "wof:parent_id":85673233,
     "wof:placetype":"county",

--- a/data/890/476/213/890476213.geojson
+++ b/data/890/476/213/890476213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037718,
-    "geom:area_square_m":381517297.369331,
+    "geom:area_square_m":381517243.814219,
     "geom:bbox":"126.370392,34.974291,126.67156,35.239069",
     "geom:latitude":35.111827,
     "geom:longitude":126.53909,
@@ -138,16 +138,18 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":28289199,
+        "meso:local_id":"36430",
         "qs_pg:id":32675,
         "wd:id":"Q50340",
         "wk:page":"Hampyeong County"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05502337e9496241ef144b255bcd1d3e",
+    "wof:geomhash":"88bc734097eb7423d3044fc7dcb5fb80",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +159,7 @@
         }
     ],
     "wof:id":890476213,
-    "wof:lastmodified":1690938314,
+    "wof:lastmodified":1695886626,
     "wof:name":"Hampyeong",
     "wof:parent_id":85673219,
     "wof:placetype":"county",

--- a/data/890/476/241/890476241.geojson
+++ b/data/890/476/241/890476241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01012,
-    "geom:area_square_m":98720107.61088,
+    "geom:area_square_m":98720001.269327,
     "geom:bbox":"127.004231,37.862829,127.156814,37.985499",
     "geom:latitude":37.917469,
     "geom:longitude":127.079561,
@@ -174,14 +174,16 @@
     "wof:concordances":{
         "gn:id":1834308,
         "gp:id":28289153,
+        "meso:local_id":"31080",
         "qs_pg:id":231144
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054068,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e71a49ee5cda9b6f4ef007e17c05be7",
+    "wof:geomhash":"0892c037465c0202948b5aff534de7f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +193,7 @@
         }
     ],
     "wof:id":890476241,
-    "wof:lastmodified":1619481389,
+    "wof:lastmodified":1695886626,
     "wof:name":"Dongducheon",
     "wof:parent_id":85673191,
     "wof:placetype":"county",

--- a/data/890/476/243/890476243.geojson
+++ b/data/890/476/243/890476243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018875,
-    "geom:area_square_m":185150017.941941,
+    "geom:area_square_m":185149681.088098,
     "geom:bbox":"128.960128,37.426639,129.161745,37.608314",
     "geom:latitude":37.506992,
     "geom:longitude":129.058262,
@@ -103,14 +103,16 @@
     "wof:concordances":{
         "gn:id":1834262,
         "gp:id":28289154,
+        "meso:local_id":"32040",
         "qs_pg:id":231145
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054068,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3657bfe62196276f32cc48c24f77e91f",
+    "wof:geomhash":"003a2aec496853eb8e1f0f76abf34e44",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +122,7 @@
         }
     ],
     "wof:id":890476243,
-    "wof:lastmodified":1627522303,
+    "wof:lastmodified":1695886767,
     "wof:name":"Donghae",
     "wof:parent_id":85673181,
     "wof:placetype":"county",

--- a/data/890/476/309/890476309.geojson
+++ b/data/890/476/309/890476309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042489,
-    "geom:area_square_m":415615831.279297,
+    "geom:area_square_m":415616273.20454,
     "geom:bbox":"126.123665,37.579472,126.544113,37.831151",
     "geom:latitude":37.713799,
     "geom:longitude":126.401262,
@@ -141,16 +141,18 @@
     "wof:concordances":{
         "gn:id":1843160,
         "gp:id":28289161,
+        "meso:local_id":"23310",
         "qs_pg:id":237039,
         "wd:id":"Q50205",
         "wk:page":"List of districts and counties of Incheon"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054071,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b79cedae2153bf70d0c713d66e662bd",
+    "wof:geomhash":"fe314949be21c920d66cf086449df80f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -160,7 +162,7 @@
         }
     ],
     "wof:id":890476309,
-    "wof:lastmodified":1690938311,
+    "wof:lastmodified":1695886768,
     "wof:name":"Ganghwa",
     "wof:parent_id":85673177,
     "wof:placetype":"county",

--- a/data/890/476/313/890476313.geojson
+++ b/data/890/476/313/890476313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001701,
-    "geom:area_square_m":16689598.574983,
+    "geom:area_square_m":16689722.127479,
     "geom:bbox":"126.920924,37.472539,126.986629,37.522889",
     "geom:latitude":37.500907,
     "geom:longitude":126.956663,
@@ -172,16 +172,18 @@
     "wof:concordances":{
         "gn:id":1834245,
         "gp:id":28289155,
+        "meso:local_id":"11200",
         "qs_pg:id":237840,
         "wd:id":"Q50385",
         "wk:page":"Dongjak District"
     },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"KR",
     "wof:created":1469054071,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dfa45c14a629435302b978a11f3ace0",
+    "wof:geomhash":"84c127a282d2b8e734fdaefcc3a966bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +193,7 @@
         }
     ],
     "wof:id":890476313,
-    "wof:lastmodified":1690938313,
+    "wof:lastmodified":1695886626,
     "wof:name":"Dongjak",
     "wof:parent_id":85673185,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.